### PR TITLE
Add support for on-chain payments

### DIFF
--- a/specs/clink-offers.md
+++ b/specs/clink-offers.md
@@ -156,7 +156,7 @@ Sent by the receiving service back to the payer.
         ["e", "<request_event_id>"],
         ["clink_version", "1"]
       ],
-      "content_onchain": "onchain_pubkey",
+      "content_onchain": "<onchain_pubkey>",
       "content": "<NIP-44 encrypted {\"bolt11\":\"<BOLT11_invoice_string>\"}>",
       "sig": "<signature>"
     }

--- a/specs/clink-offers.md
+++ b/specs/clink-offers.md
@@ -156,6 +156,7 @@ Sent by the receiving service back to the payer.
         ["e", "<request_event_id>"],
         ["clink_version", "1"]
       ],
+      "content_onchain": "onchain_pubkey",
       "content": "<NIP-44 encrypted {\"bolt11\":\"<BOLT11_invoice_string>\"}>",
       "sig": "<signature>"
     }


### PR DESCRIPTION
This PR extends the spec to allow an offer to include an on-chain payment address. This is useful for merchants/recipients who may not have any available inbound liquidity when a request comes in, but still want to process a payment. 

It would be nice for CLINK to be future-extendible for other payment forms (Ark, Fedimint, Cashu, etc), so perhaps additional payment fields/types deserve additional thought.