### PR TITLE
CLINK Enroll and Beacon specs (kind 21004, 30078)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Where NWC is deferential to LNURL and scoped for a specific task, **CLINK is fun
 - [CLINK Offers](specs/clink-offers.md): Static payment codes (`noffer1...`) analogous to LNURL-Pay but entirely Nostr-native. Enables invoice generation via Nostr direct messages without a publicly accessible HTTPS endpoint. Services like Lightning.Pub can trigger webhooks on offer events for easy integration while maintaining self-custody.
 - [CLINK Debits](specs/clink-debits.md): Static authorization pointers (`ndebit1...`) for direct, secure payment requests between parties via key-based identity and event-based authorization flows.
 - [CLINK Manage](specs/clink-manage.md): Delegated management (`nmanage1...`), e.g., external apps managing offers for a user.
+- [CLINK Enroll](specs/clink-enroll.md): Bootstrap an account on a node service for a Nostr key and receive default `noffer` / `ndebit` / `nmanage` pointers (kind `21004`). Direct-use only — does not mint third-party grants.
 
 ## Event Kinds
 
@@ -52,16 +53,18 @@ Where NWC is deferential to LNURL and scoped for a specific task, **CLINK is fun
 | 21001  | Offer Request/Response     | [CLINK Offers](specs/clink-offers.md)    |
 | 21002  | Debit Request/Response     | [CLINK Debits](specs/clink-debits.md)    |
 | 21003  | Management Delegation      | [CLINK Manage](specs/clink-manage.md)    |
+| 21004  | Enroll / account bootstrap | [CLINK Enroll](specs/clink-enroll.md)    |
 
 ## Ecosystem
 
 | Project      | Type    | Supports        | Features / Notes |
 |--------------|---------|----------------|------------------|
-| [Lightning.Pub](https://lightning.pub) | Server  | Offers, Debits | Reference server for wallets. |
+| [Lightning.Pub](https://lightning.pub) | Server  | Offers, Debits, Manage, Enroll | Reference server for wallets. |
 | [ShockWallet](https://shockwallet.app) | Wallet  | Offers, Debits | Pay offers and manage your offers and requests via Lightning.Pub. |
 | [Zeus Wallet](https://zeusln.com) | Wallet  | Offers | Pay offers, ZEUS Pay users get an offer by default. |
 | [Bridgelet](https://github.com/shocknet/bridgelet) | Bridge  | Offers         | Simple NIP-05, LNURL and Lightning Address bridge for your custom domain, uses Offers to fetch invoices from your node. |
-| [CLINK SDK](https://www.npmjs.com/package/@shocknet/clink-sdk) | SDK     | Offers, Debits | JS/TS library for CLINK integration. |
+| [CLINK SDK](https://www.npmjs.com/package/@shocknet/clink-sdk) | SDK     | Offers, Debits, Manage | JS/TS library for CLINK integration. |
+| [clink-go](https://github.com/shocknet/clink-go) | SDK + CLI | Offers, Debits, Manage, Enroll | Go SDK and `clinkctl` CLI. |
 | [Stacker.News](https://stacker.news) | Message Board | Offers, Debits | Attach a wallet via CLINK to send and receive zaps. |
 | [clinkme.dev](https://clinkme.dev) | Web Demo | Offers, Debits | Demo of a static website using CLINK Offers. |
 | [bxrd.app](https://bxrd.app) | Nostr Client | Offers, Debits | A graph-based Nostr Client with Debit integration for Zaps. |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Where NWC is deferential to LNURL and scoped for a specific task, **CLINK is fun
 - [CLINK Offers](specs/clink-offers.md): Static payment codes (`noffer1...`) analogous to LNURL-Pay but entirely Nostr-native. Enables invoice generation via Nostr direct messages without a publicly accessible HTTPS endpoint. Services like Lightning.Pub can trigger webhooks on offer events for easy integration while maintaining self-custody.
 - [CLINK Debits](specs/clink-debits.md): Static authorization pointers (`ndebit1...`) for direct, secure payment requests between parties via key-based identity and event-based authorization flows.
 - [CLINK Manage](specs/clink-manage.md): Delegated management (`nmanage1...`), e.g., external apps managing offers for a user.
-- [CLINK Enroll](specs/clink-enroll.md): Bootstrap an account on a node service for a Nostr key and receive default `noffer` / `ndebit` / `nmanage` pointers (kind `21004`). Direct-use only — does not mint third-party grants.
+- [CLINK Enroll](specs/clink-enroll.md): Kind `21004` Enroll request/response — provision a Nostr key on a node service and receive default `noffer` / `ndebit` / `nmanage` pointers. Direct-use only; does not mint third-party grants.
+- [CLINK Beacon](specs/clink-beacon.md): Optional kind `30078` heartbeat for service liveness, persona, fee disclosure, and Enroll PoW fast-path.
 
 ## Event Kinds
 
@@ -53,7 +54,8 @@ Where NWC is deferential to LNURL and scoped for a specific task, **CLINK is fun
 | 21001  | Offer Request/Response     | [CLINK Offers](specs/clink-offers.md)    |
 | 21002  | Debit Request/Response     | [CLINK Debits](specs/clink-debits.md)    |
 | 21003  | Management Delegation      | [CLINK Manage](specs/clink-manage.md)    |
-| 21004  | Enroll / account bootstrap | [CLINK Enroll](specs/clink-enroll.md)    |
+| 21004  | Enroll (Account Request)   | [CLINK Enroll](specs/clink-enroll.md)    |
+| 30078  | Service beacon (NIP-78)    | [CLINK Beacon](specs/clink-beacon.md)    |
 
 ## Ecosystem
 
@@ -64,7 +66,6 @@ Where NWC is deferential to LNURL and scoped for a specific task, **CLINK is fun
 | [Zeus Wallet](https://zeusln.com) | Wallet  | Offers | Pay offers, ZEUS Pay users get an offer by default. |
 | [Bridgelet](https://github.com/shocknet/bridgelet) | Bridge  | Offers         | Simple NIP-05, LNURL and Lightning Address bridge for your custom domain, uses Offers to fetch invoices from your node. |
 | [CLINK SDK](https://www.npmjs.com/package/@shocknet/clink-sdk) | SDK     | Offers, Debits, Manage | JS/TS library for CLINK integration. |
-| [clink-go](https://github.com/shocknet/clink-go) | SDK + CLI | Offers, Debits, Manage, Enroll | Go SDK and `clinkctl` CLI. |
 | [Stacker.News](https://stacker.news) | Message Board | Offers, Debits | Attach a wallet via CLINK to send and receive zaps. |
 | [clinkme.dev](https://clinkme.dev) | Web Demo | Offers, Debits | Demo of a static website using CLINK Offers. |
 | [bxrd.app](https://bxrd.app) | Nostr Client | Offers, Debits | A graph-based Nostr Client with Debit integration for Zaps. |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Where NWC is deferential to LNURL and scoped for a specific task, **CLINK is fun
 | [Stacker.News](https://stacker.news) | Message Board | Offers, Debits | Attach a wallet via CLINK to send and receive zaps. |
 | [clinkme.dev](https://clinkme.dev) | Web Demo | Offers, Debits | Demo of a static website using CLINK Offers. |
 | [bxrd.app](https://bxrd.app) | Nostr Client | Offers, Debits | A graph-based Nostr Client with Debit integration for Zaps. |
-| [Amtheyst](https://amethyst.social/) | Nostr Client | Offers, Debits | A privacy-focused Nostr client for Android. |
+| [Amethyst](https://amethyst.social/) | Nostr Client | Offers, Debits | A privacy-focused Nostr client for Android. |
 | [TakeMySats](https://takemysats.com) | Merchant Platform | Offers | Accept sats as payment for your products. |
 | [Woo-CLINK](https://github.com/WoompaLoompa/woo-clink) | E-commerce Plugin | Offers, Debits | Bitcoin Lightning payment gateway for WooCommerce via CLINK. |
 | [Electrum CLINK](https://github.com/BareBits/electrum_clink) | Plugin | Offers | Electrum plugin for receiving Lightning payments via CLINK noffers. |

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -1,0 +1,277 @@
+# CLINK Beacon Specification
+
+## Overview
+
+**CLINK Beacon** is a replaceable Nostr event that a node service publishes to signal **liveness**, **persona** (display metadata), and optional **protocol parameters** to clients that already know the service pubkey and relay.
+
+It complements interactive CLINK protocols (kinds `21001`–`21004`) with a lightweight, subscription-friendly heartbeat clients can watch before opening encrypted round-trips.
+
+## Motivation
+
+Wallet and CLI clients need to know whether a node is reachable before Enroll, payment, or management flows. Polling proprietary HTTP health endpoints reintroduces web infrastructure CLINK avoids.
+
+A periodic beacon on the same relay the service already uses gives clients:
+
+1. **Onlineness** — fresh `created_at` ⇒ service is likely up; stale/missing ⇒ warn or defer work
+2. **Persona** — human-readable name, avatar, and related display fields for source lists and UIs
+3. **Fee disclosure** — service fee floor and basis points before a pay flow
+4. **Enroll fast-path** — optional `enroll_difficulty` so clients can skip an Enroll probe when mining PoW (see [CLINK Enroll](clink-enroll.md))
+5. **Capability hints** — optional `supported_kinds` so clients know which CLINK kinds the node advertises
+6. **Operator linkage** — optional operator social pubkey so clients can discover or label a node by a known Nostr identity (see **Discovery by operator**). **Requires operator attestation** before trusted display (see **Operator attestation**).
+
+Beacon is **optional for servers** and **optional for clients** as an optimization. Portable behavior always remains available via Enroll probe and normal CLINK request/response flows. Beacon carries **service-level** hints only — not per-account pointers, balances, or wallet RPC (see [CLINK Enroll](clink-enroll.md)).
+
+## Nostr event
+
+Beacon uses [NIP-78](https://github.com/nostr-protocol/nips/blob/master/78.md) **addressable** kind `30078`.
+
+| Field | Value |
+|-------|--------|
+| **Kind** | `30078` |
+| **Author** | Service pubkey (same pubkey as in the service `nprofile` / TLV `0` of CLINK bech32 strings) |
+| **`d` tag** | `clink-node` |
+| **Tags** | `["operator", "<operator_pubkey_hex>"]` — optional; required when `operator_npub` is present in content (see below) |
+| **Content** | UTF-8 JSON object (schema below) |
+
+**Subscription filter (typical):**
+
+```json
+{
+  "kinds": [30078],
+  "authors": ["<service_pubkey_hex>"],
+  "#d": ["clink-node"]
+}
+```
+
+Clients SHOULD subscribe on a relay the service is known to use (from `nprofile`, prior Enroll, or beacon `relays`).
+
+To **discover nodes by operator** (“what does this `npub` run?”), clients SHOULD start from the **operator attestation** (author = operator pubkey), not `#operator` on service beacons. Spoofed services can claim any `operator_npub`; the operator-signed attestation is the authoritative service list.
+
+```json
+{
+  "kinds": [30078],
+  "authors": ["<operator_pubkey_hex>"],
+  "#d": ["clink-node-operator"]
+}
+```
+
+Read `service` tags (and check `clink-node-operator-revoke`). For each attested service pubkey `S`, fetch the `clink-node` beacon from author `S` and confirm it claims the same operator (`operator_npub` / `operator` tag). Only then treat linkage as **verified**.
+
+Clients MAY also query `#operator` on `clink-node` beacons to find **unverified** candidates, but MUST not treat matches as trusted without the operator-first path above.
+
+### Publication cadence
+
+Services that publish beacons SHOULD republish at least every **60 seconds** while online so subscribers can detect staleness without long gaps.
+
+### Client staleness
+
+Clients SHOULD treat a beacon as **stale** when no event with `created_at` within the last **180 seconds** has been seen for that service pubkey and `d` tag. Stale beacons MUST NOT be used for `enroll_difficulty` fast-path; clients fall back to Enroll probe or user warning.
+
+These intervals are recommendations; deployments MAY tune locally but SHOULD stay within similar bounds for interoperable UX.
+
+## Content schema
+
+All fields except `clink_version` are optional. Unknown fields MUST be ignored by clients.
+
+```json
+{
+  "clink_version": "1",
+  "name": "My Node",
+  "avatarUrl": "https://example.com/avatar.png",
+  "website": "https://example.com",
+  "nip05": "bob@example.com",
+  "description": "Short human-readable blurb.",
+  "operator_npub": "npub1…",
+  "relays": ["wss://relay.example.com"],
+  "fees": {
+    "serviceFeeFloor": 0,
+    "serviceFeeBps": 100
+  },
+  "enroll_difficulty": 18,
+  "supported_kinds": [21001, 21002, 21003, 21004]
+}
+```
+
+### Field definitions
+
+| Field | Type | Requirement | Description |
+|-------|------|-------------|-------------|
+| `clink_version` | string | RECOMMENDED | CLINK beacon schema version. Implementations SHOULD use `"1"`. |
+| `name` | string | RECOMMENDED when publishing | Display name for the node service. |
+| `avatarUrl` | string | optional | HTTPS URL for an avatar image. |
+| `website` | string | optional | Service website URL. |
+| `nip05` | string | optional | NIP-05 identifier for the service (verification is out of band). |
+| `description` | string | optional | Short description for UIs. |
+| `operator_npub` | string | optional | Node **operator** social Nostr identity ([NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) `npub…` bech32). Not the service CLINK pubkey (event author). When present, the event MUST include tag `["operator", "<hex_pubkey>"]` where hex is the decoded `operator_npub`. Clients MUST NOT treat this as verified without **operator attestation** (below). |
+| `relays` | string[] | optional | Relay URL(s) where the service listens for CLINK traffic. First entry MAY be treated as preferred. |
+| `fees` | object | optional | Service fee disclosure for pay flows. |
+| `fees.serviceFeeFloor` | integer | optional | Minimum service fee in **satoshis**. |
+| `fees.serviceFeeBps` | integer | optional | Service fee in basis points (100 = 1%). |
+| `enroll_difficulty` | integer | optional | NIP-13 bits the service requires for **new** Enroll when PoW is enabled. MUST **equal** the enforced required difficulty (same value as `required_difficulty` on Enroll code `4`). Not a minimum or maximum — an accurate advertisement. |
+| `supported_kinds` | integer[] | optional | CLINK event kinds this service supports (e.g. `21001` Offers, `21002` Debits, `21003` Manage, `21004` Enroll). |
+
+Monetary amounts use **satoshis**, consistent with other CLINK specs.
+
+### Discovery by operator
+
+The **service pubkey** (beacon event author) is the CLINK backend identity. The **operator pubkey** is the human operator’s everyday Nostr key.
+
+**Recommended flow** (operator-first):
+
+1. Fetch current `clink-node-operator` from the operator pubkey → attested service pubkeys (`service` tags).
+2. Subtract any pubkeys on current `clink-node-operator-revoke`.
+3. For each remaining `S`, fetch `clink-node` from author `S` and confirm `operator_npub` / `operator` tag matches the operator.
+
+Verified “operated by” UI requires steps 1–3. Starting from `#operator` on service beacons invites affinity scams — many spoofed nodes can claim the same famous `npub`.
+
+Operator linkage does **not** grant [Enroll](clink-enroll.md) owner policy on kind `21002` / `21003` for that key unless that key is also the enrolled account owner on the service.
+
+### Operator attestation
+
+A service beacon’s `operator_npub` is a **one-way claim**. Anyone can set `operator_npub` to a famous key. Clients need a **bidirectional proof**: the claimed operator key must also attest that it operates this service pubkey.
+
+The operator publishes a separate replaceable event:
+
+| Field | Value |
+|-------|--------|
+| **Kind** | `30078` |
+| **Author** | Operator pubkey (decoded `operator_npub`) |
+| **`d` tag** | `clink-node-operator` |
+| **Tags** | `["service", "<service_pubkey_hex>"]` — one tag per attested service (the list lives in tags only) |
+| **Content** | `{"clink_version": "1"}` |
+
+Service pubkeys are carried **only** in `service` tags (enables `#service` relay filters). Clients MUST NOT duplicate them in `content`.
+
+**Subscription filter (does operator attest to service `S`?):**
+
+```json
+{
+  "kinds": [30078],
+  "authors": ["<operator_pubkey_hex>"],
+  "#d": ["clink-node-operator"],
+  "#service": ["<service_pubkey_hex>"]
+}
+```
+
+**Verification** (operator pubkey `O`, service pubkey `S`):
+
+1. Service beacon (author `S`) includes `operator_npub` / `operator` tag for `O`.
+2. Current operator attestation (`d=clink-node-operator`, author `O`) includes tag `["service", "S"]`.
+3. Current revocation replaceable state does not include tag `["service", "S"]` — see **Operator attestation revocation**.
+4. Steps 1–3 satisfied ⇒ **verified** operator linkage.
+5. Beacon claims `O` but attestation missing, no `service` tag for `S`, or `S` is revoked ⇒ **unverified** — clients MUST NOT present as “operated by” without a warning; treat as possible affinity scam.
+6. Attestation tags `S` but beacon does not claim `O` ⇒ operator attestation only; no “operated by” UI from beacon alone.
+
+Clients MUST determine attestation and revocation from **current replaceable state** (latest event per `d` tag). Clients MUST NOT order these documents by `created_at` — timestamps are self-reported and not a reliable chain.
+
+**Subscription filter (full attestation document):**
+
+```json
+{
+  "kinds": [30078],
+  "authors": ["<operator_pubkey_hex>"],
+  "#d": ["clink-node-operator"]
+}
+```
+
+### Operator attestation revocation
+
+An operator MAY revoke a service without editing the attestation list by publishing a separate **replaceable** revocation document:
+
+| Field | Value |
+|-------|--------|
+| **Kind** | `30078` |
+| **Author** | Operator pubkey |
+| **`d` tag** | `clink-node-operator-revoke` |
+| **Tags** | `["service", "<service_pubkey_hex>"]` — one tag per revoked service |
+| **Content** | `{"clink_version": "1"}` |
+
+**Subscription filter (revocation document):**
+
+```json
+{
+  "kinds": [30078],
+  "authors": ["<operator_pubkey_hex>"],
+  "#d": ["clink-node-operator-revoke"]
+}
+```
+
+**Subscription filter (is service `S` revoked?):**
+
+```json
+{
+  "kinds": [30078],
+  "authors": ["<operator_pubkey_hex>"],
+  "#d": ["clink-node-operator-revoke"],
+  "#service": ["<service_pubkey_hex>"]
+}
+```
+
+**Verification with revocation** (operator `O`, service `S`): fetch the **current** `clink-node-operator` and `clink-node-operator-revoke` replaceable events from `O`. Linkage is **verified** only if attestation includes `["service", "S"]` and revocation does **not**. If both include a `service` tag for `S`, **revocation wins**. To attest again after revoke, the operator MUST republish revocation without the `S` tag (and SHOULD keep attestation consistent).
+
+Clients SHOULD fetch or subscribe to both `clink-node-operator` and `clink-node-operator-revoke` when verifying operator linkage for display.
+
+## Server requirements
+
+Services MAY publish a CLINK beacon. If they publish:
+
+- The event MUST match kind `30078`, author pubkey, and `d` tag `clink-node`.
+- `clink_version` SHOULD be `"1"`.
+- If `enroll_difficulty` is present, it MUST **equal** the required PoW difficulty enforced on kind `21004` for new enrolls (same value as `required_difficulty` when code is `4`). Services MUST NOT publish a lower or higher value than they enforce.
+- If `supported_kinds` is present, listed kinds MUST be actually supported.
+- If `fees` is present, values MUST reflect current service fee policy.
+- If `operator_npub` is present, the event MUST include `["operator", "<hex_pubkey>"]` and hex MUST match the decoded `operator_npub`. Verified display of operator identity requires matching **operator attestation** from that pubkey.
+
+Services MUST NOT rely on beacon alone for security decisions on kind `21004`; Enroll PoW validation remains on the Enroll request event.
+
+## Client requirements
+
+Clients MAY subscribe to CLINK beacons when they know service pubkey and relay.
+
+When using a beacon:
+
+1. **Onlineness** — use event `created_at` (and subscription freshness) per **Client staleness** above.
+2. **Enroll difficulty** — if `enroll_difficulty` is present and the beacon is not stale, clients MAY mine at that value before Enroll instead of probing. The Enroll request still MUST meet the service’s required difficulty (mining **at or above** required satisfies NIP-13; see [CLINK Enroll](clink-enroll.md)). On code `4`, mine at `required_difficulty` and retry once. If absent, stale, or untrusted, clients MUST use the portable Enroll probe path.
+3. **Persona / fees** — clients MAY display `name`, `avatarUrl`, etc., and show `fees` before payment; display is advisory unless cross-checked in a pay response.
+4. **Relays** — clients MAY update preferred relay hints from `relays` when reconnecting or building filters.
+5. **Operator** — for verified linkage, follow **Discovery by operator** (attestation first, then confirm `operator_npub` on each service beacon). Unverified `#operator` beacon matches alone MUST NOT show trusted “operated by” UI.
+
+Clients MUST support Enroll probe (code `4` + `required_difficulty`) regardless of beacon support.
+
+## Relationship to Enroll
+
+```
+nprofile (service pubkey + relay)
+        │
+        ▼
+ optional: subscribe kind 30078, d=clink-node
+   • stale/missing → treat as unknown / offline warning
+   • fresh + enroll_difficulty → MAY skip probe and mine
+        │
+        ▼
+ portable fallback: Enroll probe (kind 21004, 0 PoW → code 4)
+        │
+        ▼
+ kind 21004 Enroll → noffer / ndebit / nmanage
+```
+
+Beacon does not create accounts or return pointers. It only advertises parameters and liveness before Enroll.
+
+See [CLINK Enroll](clink-enroll.md) for PoW rules, probe semantics, and pointer delivery.
+
+## Security considerations
+
+- The beacon is a **signed** Nostr event from the service pubkey. The signature proves the service published this persona and hints — not that the service is trustworthy, that quoted `fees` apply to a specific invoice, or that any party is authorized to spend. Clients MUST NOT treat the beacon alone as proof of good behavior, invoice-level fee correctness, or spend authorization.
+- **Affinity scam:** a malicious service can publish any `operator_npub`. Clients MUST use bidirectional **operator attestation** and check **revocation** before trusted “operated by” display.
+- `nip05` in beacon is not verified by this spec; use NIP-05 lookup when verification matters.
+- `enroll_difficulty` fast-path is safe only when the beacon is fresh and from the expected author pubkey; otherwise probe.
+- Rate of beacon publication is a operational choice; very sparse beacons weaken onlineness signals.
+
+## Reference implementation
+
+- Spec repo: this document
+- **SDK:** [CLINK SDK](https://github.com/shocknet/ClinkSDK) ([`@shocknet/clink-sdk`](https://www.npmjs.com/package/@shocknet/clink-sdk) on npm)
+- Reference server: [Lightning.Pub](https://github.com/shocknet/Lightning.Pub) (publishes kind `30078` beacons today; migration to `d=clink-node` and `enroll_difficulty` is pending)
+- Reference wallet: [ShockWallet](https://shockwallet.app) (subscribes to service beacons for onlineness and display name)
+
+**Backward compatibility (non-normative):** some deployments historically used `d=Lightning.Pub` with a similar JSON shape. New implementations SHOULD use `d=clink-node`. The `clink-*` prefix reserves the CLINK namespace on kind `30078` (`clink-node`, `clink-node-operator`, `clink-node-operator-revoke`, …). Clients MAY accept legacy `d` tags only when explicitly targeting those deployments during a transition period.

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -8,7 +8,7 @@ It complements interactive CLINK protocols (kinds `21001`–`21004`) with a ligh
 
 ## Motivation
 
-Wallet and CLI clients need to know whether a node is reachable before Enroll, payment, or management flows. Polling proprietary HTTP health endpoints reintroduces web infrastructure CLINK avoids.
+A beacon makes it more efficient for clients to learn whether a node is reachable before Enroll, payment, or management flows. Polling proprietary HTTP health endpoints reintroduces web infrastructure that CLINK was created to avoid.
 
 A periodic beacon on the same relay the service already uses gives clients:
 
@@ -17,7 +17,7 @@ A periodic beacon on the same relay the service already uses gives clients:
 3. **Fee disclosure** — service fee floor and basis points before a pay flow
 4. **Enroll fast-path** — optional `enroll_difficulty` so clients can skip an Enroll probe when mining PoW (see [CLINK Enroll](clink-enroll.md))
 5. **Capability hints** — optional `supported_kinds` so clients know which CLINK kinds the node advertises
-6. **Operator linkage** — optional operator social pubkey so clients can discover or label a node by a known Nostr identity (see **Discovery by operator**). **Requires operator attestation** before trusted display (see **Operator attestation**).
+6. **Operator linkage** — optional `operator` tag containing the operator’s social pubkey, so clients can discover or label a node by a known Nostr identity. **Requires operator attestation** before trusted display (see **Discovery by operator**).
 
 Beacon is **optional for servers** and **optional for clients** as an optimization. Portable behavior always remains available via Enroll probe and normal CLINK request/response flows. Beacon carries **service-level** hints only — not per-account pointers, balances, or wallet RPC (see [CLINK Enroll](clink-enroll.md)).
 
@@ -29,8 +29,7 @@ Beacon uses [NIP-78](https://github.com/nostr-protocol/nips/blob/master/78.md) *
 |-------|--------|
 | **Kind** | `30078` |
 | **Author** | Service pubkey (same pubkey as in the service `nprofile` / TLV `0` of CLINK bech32 strings) |
-| **`d` tag** | `clink-node` |
-| **Tags** | `["operator", "<operator_pubkey_hex>"]` — optional; required when `operator_npub` is present in content (see below) |
+| **Tags** | Required: `["d", "clink-node"]`, `["clink_version", "1"]`. Optional: `["operator", "<operator_pubkey_hex>"]`. |
 | **Content** | UTF-8 JSON object (schema below) |
 
 **Subscription filter (typical):**
@@ -43,21 +42,9 @@ Beacon uses [NIP-78](https://github.com/nostr-protocol/nips/blob/master/78.md) *
 }
 ```
 
-Clients SHOULD subscribe on a relay the service is known to use (from `nprofile`, prior Enroll, or beacon `relays`).
+Clients leveraging beacons MUST subscribe on a relay the service is known to use (from `nprofile`, `noffer`, `ndebit`, `nmanage`, prior Enroll, or beacon `relays`).
 
-To **discover nodes by operator** (“what does this `npub` run?”), clients SHOULD start from the **operator attestation** (author = operator pubkey), not `#operator` on service beacons. Spoofed services can claim any `operator_npub`; the operator-signed attestation is the authoritative service list.
-
-```json
-{
-  "kinds": [30078],
-  "authors": ["<operator_pubkey_hex>"],
-  "#d": ["clink-node-operator"]
-}
-```
-
-Read `service` tags (and check `clink-node-operator-revoke`). For each attested service pubkey `S`, fetch the `clink-node` beacon from author `S` and confirm it claims the same operator (`operator_npub` / `operator` tag). Only then treat linkage as **verified**.
-
-Clients MAY also query `#operator` on `clink-node` beacons to find **unverified** candidates, but MUST not treat matches as trusted without the operator-first path above.
+For operator discovery and verification, clients SHOULD follow **Discovery by operator**. Querying `#operator` on service beacons alone only produces unverified candidates because spoofed services can claim any operator.
 
 ### Publication cadence
 
@@ -71,17 +58,14 @@ These intervals are recommendations; deployments MAY tune locally but SHOULD sta
 
 ## Content schema
 
-`clink_version` is required; all other fields are optional. Unknown fields MUST be ignored by clients.
+All fields are optional. Unknown fields MUST be ignored by clients.
 
 ```json
 {
-  "clink_version": "1",
   "name": "My Node",
   "avatarUrl": "https://example.com/avatar.png",
   "website": "https://example.com",
-  "nip05": "bob@example.com",
   "description": "Short human-readable blurb.",
-  "operator_npub": "npub1…",
   "relays": ["wss://relay.example.com"],
   "fees": {
     "serviceFeeFloor": 0,
@@ -96,13 +80,10 @@ These intervals are recommendations; deployments MAY tune locally but SHOULD sta
 
 | Field | Type | Requirement | Description |
 |-------|------|-------------|-------------|
-| `clink_version` | string | required | `"1"` |
 | `name` | string | optional | Display name for the node service. |
 | `avatarUrl` | string | optional | HTTPS URL for an avatar image. |
 | `website` | string | optional | Service website URL. |
-| `nip05` | string | optional | NIP-05 identifier for the service (verification is out of band). |
 | `description` | string | optional | Short description for UIs. |
-| `operator_npub` | string | optional | Node **operator** social Nostr identity ([NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) `npub…` bech32). Not the service CLINK pubkey (event author). When present, the event MUST include tag `["operator", "<hex_pubkey>"]` where hex is the decoded `operator_npub`. Clients MUST NOT treat this as verified without **operator attestation** (below). |
 | `relays` | string[] | optional | Relay URL(s) where the service listens for CLINK traffic. First entry MAY be treated as preferred. |
 | `fees` | object | optional | Service fee disclosure for pay flows. |
 | `fees.serviceFeeFloor` | integer | optional | Minimum service fee in **satoshis**. |
@@ -116,63 +97,34 @@ Monetary amounts use **satoshis**, consistent with other CLINK specs.
 
 The **service pubkey** (beacon event author) is the CLINK backend identity. The **operator pubkey** is the human operator’s everyday Nostr key.
 
-**Recommended flow** (operator-first):
+**Verification flow** (operator-first):
 
 1. Fetch current `clink-node-operator` from the operator pubkey → attested service pubkeys (`service` tags).
 2. Subtract any pubkeys on current `clink-node-operator-revoke`.
-3. For each remaining `S`, fetch `clink-node` from author `S` and confirm `operator_npub` / `operator` tag matches the operator.
+3. For each remaining `S`, fetch `clink-node` from author `S` and confirm tag `["operator", "<operator_pubkey_hex>"]`.
 
-Verified “operated by” UI requires steps 1–3. Starting from `#operator` on service beacons invites affinity scams — many spoofed nodes can claim the same famous `npub`.
+Only then may a client show verified “operated by” UI. Starting from `#operator` on service beacons invites affinity scams because many spoofed nodes can claim the same famous `npub`.
 
 Operator linkage does **not** grant [Enroll](clink-enroll.md) owner policy on kind `21002` / `21003` for that key unless that key is also the enrolled account owner on the service.
 
 ### Operator attestation
 
-A service beacon’s `operator_npub` is a **one-way claim**. Anyone can set `operator_npub` to a famous key. Clients need a **bidirectional proof**: the claimed operator key must also attest that it operates this service pubkey.
+A service beacon’s `operator` tag is a **one-way claim**. Anyone can tag a famous key. Clients need a **bidirectional proof**: the claimed operator key must also attest that it operates this service pubkey.
 
 The operator publishes a separate replaceable event:
 
 | Field | Value |
 |-------|--------|
 | **Kind** | `30078` |
-| **Author** | Operator pubkey (decoded `operator_npub`) |
-| **`d` tag** | `clink-node-operator` |
-| **Tags** | `["service", "<service_pubkey_hex>"]` — one tag per attested service (the list lives in tags only) |
-| **Content** | `{"clink_version": "1"}` |
+| **Author** | Operator pubkey |
+| **Tags** | Required: `["d", "clink-node-operator"]`, `["clink_version", "1"]`. `["service", "<service_pubkey_hex>"]` per attested service. |
+| **Content** | `""` |
 
 Service pubkeys are carried **only** in `service` tags (enables `#service` relay filters). Clients MUST NOT duplicate them in `content`.
 
-**Subscription filter (does operator attest to service `S`?):**
-
-```json
-{
-  "kinds": [30078],
-  "authors": ["<operator_pubkey_hex>"],
-  "#d": ["clink-node-operator"],
-  "#service": ["<service_pubkey_hex>"]
-}
-```
-
-**Verification** (operator pubkey `O`, service pubkey `S`):
-
-1. Service beacon (author `S`) includes `operator_npub` / `operator` tag for `O`.
-2. Current operator attestation (`d=clink-node-operator`, author `O`) includes tag `["service", "S"]`.
-3. Current revocation replaceable state does not include tag `["service", "S"]` — see **Operator attestation revocation**.
-4. Steps 1–3 satisfied ⇒ **verified** operator linkage.
-5. Beacon claims `O` but attestation missing, no `service` tag for `S`, or `S` is revoked ⇒ **unverified** — clients MUST NOT present as “operated by” without a warning; treat as possible affinity scam.
-6. Attestation tags `S` but beacon does not claim `O` ⇒ operator attestation only; no “operated by” UI from beacon alone.
+For operator `O` and service `S`, linkage is verified only when the service beacon authored by `S` includes `["operator", "O"]`, the current attestation authored by `O` includes `["service", "S"]`, and the current revocation state does not include `["service", "S"]`. If any condition is missing, or if `S` is revoked, clients MUST NOT present the service as “operated by” `O`. An attestation for `S` without a matching service-beacon claim is only an operator assertion, not verified beacon linkage.
 
 Clients MUST determine attestation and revocation from **current replaceable state** (latest event per `d` tag). Clients MUST NOT order these documents by `created_at` — timestamps are self-reported and not a reliable chain.
-
-**Subscription filter (full attestation document):**
-
-```json
-{
-  "kinds": [30078],
-  "authors": ["<operator_pubkey_hex>"],
-  "#d": ["clink-node-operator"]
-}
-```
 
 ### Operator attestation revocation
 
@@ -182,9 +134,8 @@ An operator MAY revoke a service without editing the attestation list by publish
 |-------|--------|
 | **Kind** | `30078` |
 | **Author** | Operator pubkey |
-| **`d` tag** | `clink-node-operator-revoke` |
-| **Tags** | `["service", "<service_pubkey_hex>"]` — one tag per revoked service |
-| **Content** | `{"clink_version": "1"}` |
+| **Tags** | Required: `["d", "clink-node-operator-revoke"]`, `["clink_version", "1"]`. `["service", "<service_pubkey_hex>"]` per revoked service. |
+| **Content** | `""` |
 
 **Subscription filter (revocation document):**
 
@@ -196,17 +147,6 @@ An operator MAY revoke a service without editing the attestation list by publish
 }
 ```
 
-**Subscription filter (is service `S` revoked?):**
-
-```json
-{
-  "kinds": [30078],
-  "authors": ["<operator_pubkey_hex>"],
-  "#d": ["clink-node-operator-revoke"],
-  "#service": ["<service_pubkey_hex>"]
-}
-```
-
 **Verification with revocation** (operator `O`, service `S`): fetch the **current** `clink-node-operator` and `clink-node-operator-revoke` replaceable events from `O`. Linkage is **verified** only if attestation includes `["service", "S"]` and revocation does **not**. If both include a `service` tag for `S`, **revocation wins**. To attest again after revoke, the operator MUST republish revocation without the `S` tag (and SHOULD keep attestation consistent).
 
 Clients SHOULD fetch or subscribe to both `clink-node-operator` and `clink-node-operator-revoke` when verifying operator linkage for display.
@@ -215,11 +155,11 @@ Clients SHOULD fetch or subscribe to both `clink-node-operator` and `clink-node-
 
 Services MAY publish a CLINK beacon. If they publish:
 
-- The event MUST match kind `30078`, author pubkey, `d` tag `clink-node`, and `content` with `clink_version: "1"`.
+- The event MUST be kind `30078`, author service pubkey, with tags `["d", "clink-node"]` and `["clink_version", "1"]`.
 - If `enroll_difficulty` is present, it MUST **equal** the required PoW difficulty enforced on kind `21004` for new enrolls (same value as `required_difficulty` when code is `4`). Services MUST NOT publish a lower or higher value than they enforce.
 - If `supported_kinds` is present, listed kinds MUST be actually supported.
 - If `fees` is present, values MUST reflect current service fee policy.
-- If `operator_npub` is present, the event MUST include `["operator", "<hex_pubkey>"]` and hex MUST match the decoded `operator_npub`. Verified display of operator identity requires matching **operator attestation** from that pubkey.
+- If an `operator` tag is present, verified display of operator identity requires matching **operator attestation** from that pubkey.
 
 Services MUST NOT rely on beacon alone for security decisions on kind `21004`; Enroll PoW validation remains on the Enroll request event.
 
@@ -233,7 +173,7 @@ When using a beacon:
 2. **Enroll difficulty** — if `enroll_difficulty` is present and the beacon is not stale, clients MAY mine at that value before Enroll instead of probing. The Enroll request still MUST meet the service’s required difficulty (mining **at or above** required satisfies NIP-13; see [CLINK Enroll](clink-enroll.md)). On code `4`, mine at `required_difficulty` and retry once. If absent, stale, or untrusted, clients MUST use the portable Enroll probe path.
 3. **Persona / fees** — clients MAY display `name`, `avatarUrl`, etc., and show `fees` before payment; display is advisory unless cross-checked in a pay response.
 4. **Relays** — clients MAY update preferred relay hints from `relays` when reconnecting or building filters.
-5. **Operator** — for verified linkage, follow **Discovery by operator** (attestation first, then confirm `operator_npub` on each service beacon). Unverified `#operator` beacon matches alone MUST NOT show trusted “operated by” UI.
+5. **Operator** — clients MUST follow **Discovery by operator** for verified linkage. Unverified `#operator` beacon matches alone MUST NOT show trusted “operated by” UI.
 
 Clients MUST support Enroll probe (code `4` + `required_difficulty`) regardless of beacon support.
 
@@ -261,10 +201,9 @@ See [CLINK Enroll](clink-enroll.md) for PoW rules, probe semantics, and pointer 
 ## Security considerations
 
 - The beacon is a **signed** Nostr event from the service pubkey. The signature proves the service published this persona and hints — not that the service is trustworthy, that quoted `fees` apply to a specific invoice, or that any party is authorized to spend. Clients MUST NOT treat the beacon alone as proof of good behavior, invoice-level fee correctness, or spend authorization.
-- **Affinity scam:** a malicious service can publish any `operator_npub`. Clients MUST use bidirectional **operator attestation** and check **revocation** before trusted “operated by” display.
-- `nip05` in beacon is not verified by this spec; use NIP-05 lookup when verification matters.
+- **Affinity scam:** a malicious service can tag any operator pubkey. Clients MUST use bidirectional **operator attestation** and check **revocation** before displaying “operated by”.
 - `enroll_difficulty` fast-path is safe only when the beacon is fresh and from the expected author pubkey; otherwise probe.
-- Rate of beacon publication is a operational choice; very sparse beacons weaken onlineness signals.
+- Rate of beacon publication is an operational choice; very sparse beacons weaken onlineness signals.
 
 ## Reference implementation
 

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -155,7 +155,7 @@ An operator MAY revoke a service without editing the attestation list by publish
 }
 ```
 
-To re-attest after revoke, the operator MUST republish revocation without the `S` tag (and SHOULD keep attestation consistent). Clients SHOULD subscribe to both documents when verifying operator linkage.
+To re-attest after revoke, the operator MUST republish revocation without the corresponding `service` tag and keep attestation consistent. Before treating operator linkage as verified, clients MUST check both the current attestation and revocation documents.
 
 ## Server requirements
 

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -180,12 +180,10 @@ Clients MAY subscribe to CLINK beacons when they know service pubkey and relay.
 When using a beacon:
 
 1. **Onlineness** — use event `created_at` (and subscription freshness) per **Client staleness** above.
-2. **Enroll difficulty** — if `enroll_difficulty` is present and the beacon is not stale, clients MAY mine at that value before Enroll instead of probing. The Enroll request still MUST meet the service’s required difficulty (mining **at or above** required satisfies NIP-13; see [CLINK Enroll](clink-enroll.md)). On code `5`, mine at `required_difficulty` and retry once. If absent, stale, or untrusted, clients MUST use the portable Enroll probe path.
+2. **Enroll difficulty** — if `enroll_difficulty` is present and the beacon is valid per **Client staleness** above, clients MAY use it as the Enroll PoW fast-path (see [CLINK Enroll](clink-enroll.md)). Otherwise fall back to the portable Enroll probe path.
 3. **Persona / fees** — clients MAY display `name`, `avatarUrl`, etc., and show `fees` before payment; display is advisory unless cross-checked in a pay response.
 4. **Relays** — clients MAY update preferred relay hints from `relays` when reconnecting or building filters.
 5. **Operator** — clients MUST follow **Discovery by operator** for verified linkage. Unverified `#operator` beacon matches alone MUST NOT show trusted “operated by” UI.
-
-Clients MUST support Enroll probe (code `5` + `required_difficulty`) regardless of beacon support.
 
 ## Relationship to Enroll
 
@@ -206,7 +204,7 @@ nprofile (service pubkey + relay)
 
 Beacon does not create accounts or return pointers. It only advertises parameters and liveness before Enroll.
 
-See [CLINK Enroll](clink-enroll.md) for PoW rules, probe semantics, and pointer delivery.
+See [CLINK Enroll](clink-enroll.md) for PoW rules, probe semantics, and resource pointer delivery.
 
 ## Security considerations
 

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -54,6 +54,8 @@ Services that publish beacons SHOULD republish at least every **60 seconds** whi
 
 Clients SHOULD treat a beacon as **stale** when no event with `created_at` within the last **180 seconds** has been seen for that service pubkey and `d` tag. Stale beacons MUST NOT be used for `enroll_difficulty` fast-path; clients fall back to Enroll probe or user warning.
 
+Clients SHOULD treat a beacon whose `created_at` is more than **30 seconds in the future** as invalid for freshness and protocol-parameter decisions.
+
 These intervals are recommendations; deployments MAY tune locally but SHOULD stay within similar bounds for interoperable UX.
 
 ## Content schema
@@ -84,7 +86,7 @@ All fields are optional. Unknown fields MUST be ignored by clients.
 | `avatarUrl` | string | optional | HTTPS URL for an avatar image. |
 | `website` | string | optional | Service website URL. |
 | `description` | string | optional | Short description for UIs. |
-| `relays` | string[] | optional | Relay URL(s) where the service listens for CLINK traffic. First entry MAY be treated as preferred. |
+| `relays` | string[] | optional | Valid WebSocket relay URL(s) where the service listens for CLINK traffic. Production entries SHOULD use `wss:`. First entry MAY be treated as preferred. |
 | `fees` | object | optional | Service fee disclosure for pay flows. |
 | `fees.serviceFeeFloor` | integer | optional | Minimum service fee in **satoshis**. |
 | `fees.serviceFeeBps` | integer | optional | Service fee in basis points (100 = 1%). |
@@ -124,7 +126,7 @@ Service pubkeys are carried **only** in `service` tags (enables `#service` relay
 
 For operator `O` and service `S`, linkage is verified only when the service beacon authored by `S` includes `["operator", "O"]`, the current attestation authored by `O` includes `["service", "S"]`, and the current revocation state does not include `["service", "S"]`. If any condition is missing, or if `S` is revoked, clients MUST NOT present the service as “operated by” `O`. An attestation for `S` without a matching service-beacon claim is only an operator assertion, not verified beacon linkage.
 
-Clients MUST determine attestation and revocation from **current replaceable state** (latest event per `d` tag). Clients MUST NOT order these documents by `created_at` — timestamps are self-reported and not a reliable chain.
+Clients MUST determine attestation and revocation from the **current addressable event** for each coordinate according to NIP-01 replacement rules. Clients MUST NOT compare the attestation document’s `created_at` with the revocation document’s `created_at` to decide which document wins; membership in the current revocation document wins.
 
 ### Operator attestation revocation
 

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -52,7 +52,7 @@ Implementations MUST include this tag in beacon, operator attestation, and revoc
 
 Clients leveraging beacons MUST subscribe on a relay the service is known to use (from `nprofile`, `noffer`, `ndebit`, `nmanage`, prior Enroll, or beacon `relays`).
 
-For operator discovery and verification, clients SHOULD follow **Discovery by operator**. Querying `#operator` on service beacons alone only produces unverified candidates because spoofed services can claim any operator.
+For operator discovery and verification, clients SHOULD follow **Discovery by operator**. An `operator` claim on a service beacon alone is unverified because spoofed services can claim any operator.
 
 ### Publication cadence
 
@@ -113,7 +113,7 @@ The **service pubkey** (beacon event author) is the CLINK backend identity. The 
 2. Subtract any pubkeys on current `clink-node-operator-revoke` (if both list `S`, **revocation wins**).
 3. For each remaining `S`, fetch `clink-node` from author `S` and confirm tag `["operator", "<operator_pubkey_hex>"]`.
 
-Only then may a client show verified “operated by” UI. Starting from `#operator` on service beacons invites affinity scams — spoofed nodes can claim any famous `npub`.
+Only then may a client show verified “operated by” UI. Trusting the `operator` claim on a service beacon alone invites affinity scams — spoofed nodes can claim any famous `npub`.
 
 ### Operator attestation
 
@@ -128,7 +128,7 @@ The operator publishes a separate replaceable event:
 | **Tags** | Required: `["d", "clink-node-operator"]`, `["clink_version", "1"]`. `["service", "<service_pubkey_hex>"]` per attested service. |
 | **Content** | `""` |
 
-Service pubkeys are carried **only** in `service` tags (enables `#service` relay filters). Clients MUST NOT duplicate them in `content`.
+Service pubkeys are carried **only** in `service` tags. Clients inspect these tags after fetching the document by operator author and `d` tag. Clients MUST NOT duplicate them in `content`.
 
 Clients MUST use the **current** attestation and revocation events per NIP-01 replacement rules. Do **not** compare `created_at` across the two documents; membership in the current revocation document wins.
 
@@ -173,7 +173,7 @@ When using a beacon:
 2. **Enroll difficulty** — if `enroll_difficulty` is present and the beacon is valid per **Client staleness** above, clients MAY use it as the Enroll PoW fast-path (see [CLINK Enroll](clink-enroll.md)). Otherwise fall back to the portable Enroll probe path.
 3. **Persona / fees** — clients MAY display `name`, `avatarUrl`, etc., and show `fees` before payment; display is advisory unless cross-checked in a pay response.
 4. **Relays** — clients MAY update preferred relay hints from `relays` when reconnecting or building filters.
-5. **Operator** — clients MUST follow **Discovery by operator** for verified linkage. Unverified `#operator` beacon matches alone MUST NOT show trusted “operated by” UI.
+5. **Operator** — clients MUST follow **Discovery by operator** for verified linkage. An unverified `operator` claim on a service beacon alone MUST NOT show trusted “operated by” UI.
 
 ## Security considerations
 

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -71,7 +71,7 @@ These intervals are recommendations; deployments MAY tune locally but SHOULD sta
 
 ## Content schema
 
-All fields except `clink_version` are optional. Unknown fields MUST be ignored by clients.
+`clink_version` is required; all other fields are optional. Unknown fields MUST be ignored by clients.
 
 ```json
 {
@@ -96,8 +96,8 @@ All fields except `clink_version` are optional. Unknown fields MUST be ignored b
 
 | Field | Type | Requirement | Description |
 |-------|------|-------------|-------------|
-| `clink_version` | string | RECOMMENDED | CLINK beacon schema version. Implementations SHOULD use `"1"`. |
-| `name` | string | RECOMMENDED when publishing | Display name for the node service. |
+| `clink_version` | string | required | `"1"` |
+| `name` | string | optional | Display name for the node service. |
 | `avatarUrl` | string | optional | HTTPS URL for an avatar image. |
 | `website` | string | optional | Service website URL. |
 | `nip05` | string | optional | NIP-05 identifier for the service (verification is out of band). |
@@ -215,8 +215,7 @@ Clients SHOULD fetch or subscribe to both `clink-node-operator` and `clink-node-
 
 Services MAY publish a CLINK beacon. If they publish:
 
-- The event MUST match kind `30078`, author pubkey, and `d` tag `clink-node`.
-- `clink_version` SHOULD be `"1"`.
+- The event MUST match kind `30078`, author pubkey, `d` tag `clink-node`, and `content` with `clink_version: "1"`.
 - If `enroll_difficulty` is present, it MUST **equal** the required PoW difficulty enforced on kind `21004` for new enrolls (same value as `required_difficulty` when code is `4`). Services MUST NOT publish a lower or higher value than they enforce.
 - If `supported_kinds` is present, listed kinds MUST be actually supported.
 - If `fees` is present, values MUST reflect current service fee policy.

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -103,6 +103,8 @@ All fields are optional. Unknown fields MUST be ignored by clients.
 
 Monetary amounts use **satoshis**, consistent with other CLINK specs.
 
+For a payment amount `amount_sats`, the advertised service fee is the greater of `serviceFeeFloor` and `amount_sats × serviceFeeBps / 10,000`. Services MAY round a fractional result up to the next whole satoshi, since millisatoshis are accounting precision rather than independently settleable value. This remains an advisory disclosure; the payment flow is authoritative.
+
 ### Discovery by operator
 
 The **service pubkey** (beacon event author) is the CLINK backend identity. The **operator pubkey** is the human operator’s everyday Nostr key.
@@ -166,6 +168,8 @@ Services MAY publish a CLINK beacon. If they publish:
 ## Client requirements
 
 Clients MAY subscribe to CLINK beacons when they know service pubkey and relay.
+
+Before using a beacon, clients MUST verify its NIP-01 event ID and signature, required kind and tags, and that its author is the expected service pubkey. Clients verifying operator attestation or revocation documents MUST likewise verify their event IDs, signatures, required kind and tags, and expected operator author.
 
 When using a beacon:
 

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -88,7 +88,7 @@ All fields are optional. Unknown fields MUST be ignored by clients.
 | `fees` | object | optional | Service fee disclosure for pay flows. |
 | `fees.serviceFeeFloor` | integer | optional | Minimum service fee in **satoshis**. |
 | `fees.serviceFeeBps` | integer | optional | Service fee in basis points (100 = 1%). |
-| `enroll_difficulty` | integer | optional | NIP-13 bits the service requires for **new** Enroll when PoW is enabled. MUST **equal** the enforced required difficulty (same value as `required_difficulty` on Enroll code `4`). Not a minimum or maximum — an accurate advertisement. |
+| `enroll_difficulty` | integer | optional | NIP-13 bits the service requires for **new** Enroll when PoW is enabled. MUST **equal** the enforced required difficulty (same value as `required_difficulty` on Enroll code `5`). Not a minimum or maximum — an accurate advertisement. |
 | `supported_kinds` | integer[] | optional | CLINK event kinds this service supports (e.g. `21001` Offers, `21002` Debits, `21003` Manage, `21004` Enroll). |
 
 Monetary amounts use **satoshis**, consistent with other CLINK specs.
@@ -156,7 +156,7 @@ Clients SHOULD fetch or subscribe to both `clink-node-operator` and `clink-node-
 Services MAY publish a CLINK beacon. If they publish:
 
 - The event MUST be kind `30078`, author service pubkey, with tags `["d", "clink-node"]` and `["clink_version", "1"]`.
-- If `enroll_difficulty` is present, it MUST **equal** the required PoW difficulty enforced on kind `21004` for new enrolls (same value as `required_difficulty` when code is `4`). Services MUST NOT publish a lower or higher value than they enforce.
+- If `enroll_difficulty` is present, it MUST **equal** the required PoW difficulty enforced on kind `21004` for new enrolls (same value as `required_difficulty` when code is `5`). Services MUST NOT publish a lower or higher value than they enforce.
 - If `supported_kinds` is present, listed kinds MUST be actually supported.
 - If `fees` is present, values MUST reflect current service fee policy.
 - If an `operator` tag is present, verified display of operator identity requires matching **operator attestation** from that pubkey.
@@ -170,12 +170,12 @@ Clients MAY subscribe to CLINK beacons when they know service pubkey and relay.
 When using a beacon:
 
 1. **Onlineness** — use event `created_at` (and subscription freshness) per **Client staleness** above.
-2. **Enroll difficulty** — if `enroll_difficulty` is present and the beacon is not stale, clients MAY mine at that value before Enroll instead of probing. The Enroll request still MUST meet the service’s required difficulty (mining **at or above** required satisfies NIP-13; see [CLINK Enroll](clink-enroll.md)). On code `4`, mine at `required_difficulty` and retry once. If absent, stale, or untrusted, clients MUST use the portable Enroll probe path.
+2. **Enroll difficulty** — if `enroll_difficulty` is present and the beacon is not stale, clients MAY mine at that value before Enroll instead of probing. The Enroll request still MUST meet the service’s required difficulty (mining **at or above** required satisfies NIP-13; see [CLINK Enroll](clink-enroll.md)). On code `5`, mine at `required_difficulty` and retry once. If absent, stale, or untrusted, clients MUST use the portable Enroll probe path.
 3. **Persona / fees** — clients MAY display `name`, `avatarUrl`, etc., and show `fees` before payment; display is advisory unless cross-checked in a pay response.
 4. **Relays** — clients MAY update preferred relay hints from `relays` when reconnecting or building filters.
 5. **Operator** — clients MUST follow **Discovery by operator** for verified linkage. Unverified `#operator` beacon matches alone MUST NOT show trusted “operated by” UI.
 
-Clients MUST support Enroll probe (code `4` + `required_difficulty`) regardless of beacon support.
+Clients MUST support Enroll probe (code `5` + `required_difficulty`) regardless of beacon support.
 
 ## Relationship to Enroll
 
@@ -188,7 +188,7 @@ nprofile (service pubkey + relay)
    • fresh + enroll_difficulty → MAY skip probe and mine
         │
         ▼
- portable fallback: Enroll probe (kind 21004, 0 PoW → code 4)
+ portable fallback: Enroll probe (kind 21004, 0 PoW → code 5)
         │
         ▼
  kind 21004 Enroll → noffer / ndebit / nmanage

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -17,7 +17,7 @@ A periodic beacon on the same relay the service already uses gives clients:
 3. **Fee disclosure** — service fee floor and basis points before a pay flow
 4. **Enroll fast-path** — optional `enroll_difficulty` so clients can skip an Enroll probe when mining PoW (see [CLINK Enroll](clink-enroll.md))
 5. **Capability hints** — optional `supported_kinds` so clients know which CLINK kinds the node advertises
-6. **Operator linkage** — optional `operator` tag containing the operator’s social pubkey, so clients can discover or label a node by a known Nostr identity. **Requires operator attestation** before trusted display (see **Discovery by operator**).
+6. **Operator linkage** — optional `operator` tag for the operator’s social pubkey. Trusted “operated by” display requires attestation (see **Discovery by operator**).
 
 Beacon is **optional for servers** and **optional for clients** as an optimization. Portable behavior always remains available via Enroll probe and normal CLINK request/response flows. Beacon carries **service-level** hints only — not per-account pointers, balances, or wallet RPC (see [CLINK Enroll](clink-enroll.md)).
 
@@ -110,16 +110,14 @@ The **service pubkey** (beacon event author) is the CLINK backend identity. The 
 **Verification flow** (operator-first):
 
 1. Fetch current `clink-node-operator` from the operator pubkey → attested service pubkeys (`service` tags).
-2. Subtract any pubkeys on current `clink-node-operator-revoke`.
+2. Subtract any pubkeys on current `clink-node-operator-revoke` (if both list `S`, **revocation wins**).
 3. For each remaining `S`, fetch `clink-node` from author `S` and confirm tag `["operator", "<operator_pubkey_hex>"]`.
 
-Only then may a client show verified “operated by” UI. Starting from `#operator` on service beacons invites affinity scams because many spoofed nodes can claim the same famous `npub`.
-
-Operator linkage does **not** grant [Enroll](clink-enroll.md) owner policy on kind `21002` / `21003` for that key unless that key is also the enrolled account owner on the service.
+Only then may a client show verified “operated by” UI. Starting from `#operator` on service beacons invites affinity scams — spoofed nodes can claim any famous `npub`.
 
 ### Operator attestation
 
-A service beacon’s `operator` tag is a **one-way claim**. Anyone can tag a famous key. Clients need a **bidirectional proof**: the claimed operator key must also attest that it operates this service pubkey.
+A service beacon’s `operator` tag is a **one-way claim**. Anyone can tag a famous key. Clients need **bidirectional proof**: the claimed operator key must also attest this service pubkey.
 
 The operator publishes a separate replaceable event:
 
@@ -132,9 +130,7 @@ The operator publishes a separate replaceable event:
 
 Service pubkeys are carried **only** in `service` tags (enables `#service` relay filters). Clients MUST NOT duplicate them in `content`.
 
-For operator `O` and service `S`, linkage is verified only when the service beacon authored by `S` includes `["operator", "O"]`, the current attestation authored by `O` includes `["service", "S"]`, and the current revocation state does not include `["service", "S"]`. If any condition is missing, or if `S` is revoked, clients MUST NOT present the service as “operated by” `O`. An attestation for `S` without a matching service-beacon claim is only an operator assertion, not verified beacon linkage.
-
-Clients MUST determine attestation and revocation from the **current addressable event** for each coordinate according to NIP-01 replacement rules. Clients MUST NOT compare the attestation document’s `created_at` with the revocation document’s `created_at` to decide which document wins; membership in the current revocation document wins.
+Clients MUST use the **current** attestation and revocation events per NIP-01 replacement rules. Do **not** compare `created_at` across the two documents; membership in the current revocation document wins.
 
 ### Operator attestation revocation
 
@@ -157,21 +153,15 @@ An operator MAY revoke a service without editing the attestation list by publish
 }
 ```
 
-**Verification with revocation** (operator `O`, service `S`): fetch the **current** `clink-node-operator` and `clink-node-operator-revoke` replaceable events from `O`. Linkage is **verified** only if attestation includes `["service", "S"]` and revocation does **not**. If both include a `service` tag for `S`, **revocation wins**. To attest again after revoke, the operator MUST republish revocation without the `S` tag (and SHOULD keep attestation consistent).
-
-Clients SHOULD fetch or subscribe to both `clink-node-operator` and `clink-node-operator-revoke` when verifying operator linkage for display.
+To re-attest after revoke, the operator MUST republish revocation without the `S` tag (and SHOULD keep attestation consistent). Clients SHOULD subscribe to both documents when verifying operator linkage.
 
 ## Server requirements
 
 Services MAY publish a CLINK beacon. If they publish:
 
-- The event MUST be kind `30078`, author service pubkey, with tags `["d", "clink-node"]` and `["clink_version", "1"]`.
-- If `enroll_difficulty` is present, it MUST **equal** the required PoW difficulty enforced on kind `21004` for new enrolls (same value as `required_difficulty` when code is `5`). Services MUST NOT publish a lower or higher value than they enforce.
-- If `supported_kinds` is present, listed kinds MUST be actually supported.
-- If `fees` is present, values MUST reflect current service fee policy.
-- If an `operator` tag is present, verified display of operator identity requires matching **operator attestation** from that pubkey.
-
-Services MUST NOT rely on beacon alone for security decisions on kind `21004`; Enroll PoW validation remains on the Enroll request event.
+- The event MUST match the **Nostr event** table above (`30078`, service author, required tags).
+- Advertised `enroll_difficulty`, `supported_kinds`, and `fees` MUST match what the service actually enforces.
+- Services MUST NOT rely on beacon alone for security decisions on kind `21004`; Enroll PoW validation remains on the Enroll request event.
 
 ## Client requirements
 
@@ -185,33 +175,11 @@ When using a beacon:
 4. **Relays** — clients MAY update preferred relay hints from `relays` when reconnecting or building filters.
 5. **Operator** — clients MUST follow **Discovery by operator** for verified linkage. Unverified `#operator` beacon matches alone MUST NOT show trusted “operated by” UI.
 
-## Relationship to Enroll
-
-```
-nprofile (service pubkey + relay)
-        │
-        ▼
- optional: subscribe kind 30078, d=clink-node
-   • stale/missing → treat as unknown / offline warning
-   • fresh + enroll_difficulty → MAY skip probe and mine
-        │
-        ▼
- portable fallback: Enroll probe (kind 21004, 0 PoW → code 5)
-        │
-        ▼
- kind 21004 Enroll → noffer / ndebit / nmanage
-```
-
-Beacon does not create accounts or return pointers. It only advertises parameters and liveness before Enroll.
-
-See [CLINK Enroll](clink-enroll.md) for PoW rules, probe semantics, and resource pointer delivery.
-
 ## Security considerations
 
-- The beacon is a **signed** Nostr event from the service pubkey. The signature proves the service published this persona and hints — not that the service is trustworthy, that quoted `fees` apply to a specific invoice, or that any party is authorized to spend. Clients MUST NOT treat the beacon alone as proof of good behavior, invoice-level fee correctness, or spend authorization.
-- **Affinity scam:** a malicious service can tag any operator pubkey. Clients MUST use bidirectional **operator attestation** and check **revocation** before displaying “operated by”.
-- `enroll_difficulty` fast-path is safe only when the beacon is fresh and from the expected author pubkey; otherwise probe.
-- Rate of beacon publication is an operational choice; very sparse beacons weaken onlineness signals.
+- The beacon is a **signed** event from the service pubkey. That proves authorship of the persona/hints — not trustworthiness, invoice-level fee correctness, or spend authorization.
+- **Affinity scam:** a malicious service can tag any operator pubkey. Require bidirectional attestation and check revocation before “operated by” UI.
+- `enroll_difficulty` fast-path only when the beacon is valid per **Client staleness** and from the expected author; otherwise probe.
 
 ## Reference Implementations
 

--- a/specs/clink-beacon.md
+++ b/specs/clink-beacon.md
@@ -32,6 +32,14 @@ Beacon uses [NIP-78](https://github.com/nostr-protocol/nips/blob/master/78.md) *
 | **Tags** | Required: `["d", "clink-node"]`, `["clink_version", "1"]`. Optional: `["operator", "<operator_pubkey_hex>"]`. |
 | **Content** | UTF-8 JSON object (schema below) |
 
+### Protocol Versioning
+
+CLINK events utilize a mandatory `["clink_version", "1"]` tag. This ensures:
+1. **Disambiguation:** Explicitly identifies events belonging to the CLINK protocol, preventing conflicts if other NIPs use the same event kind (`30078`).
+2. **Version Compatibility:** Allows clients and services to verify they are using compatible versions of the CLINK protocol specification. Future versions may increment the version number (e.g., `"2"`).
+
+Implementations MUST include this tag in beacon, operator attestation, and revocation events.
+
 **Subscription filter (typical):**
 
 ```json
@@ -207,7 +215,7 @@ See [CLINK Enroll](clink-enroll.md) for PoW rules, probe semantics, and pointer 
 - `enroll_difficulty` fast-path is safe only when the beacon is fresh and from the expected author pubkey; otherwise probe.
 - Rate of beacon publication is an operational choice; very sparse beacons weaken onlineness signals.
 
-## Reference implementation
+## Reference Implementations
 
 - Spec repo: this document
 - **SDK:** [CLINK SDK](https://github.com/shocknet/ClinkSDK) ([`@shocknet/clink-sdk`](https://www.npmjs.com/package/@shocknet/clink-sdk) on npm)

--- a/specs/clink-debits.md
+++ b/specs/clink-debits.md
@@ -326,6 +326,7 @@ Implementations MUST include this tag in both request and response events and SH
 - Validate incoming requests.
 - Send kind `21002` responses (`ok` or `GFY`).
 - Process Lightning payments securely for approved direct payment requests.
+- Allow direct operations signed by the account owner key without a prior third-party authorization grant (see **Owner policy** in [CLINK Enroll](clink-enroll.md)).
 
 **SHOULD:**
 - Provide a UI for users to manage permissions, budgets, and rules.

--- a/specs/clink-debits.md
+++ b/specs/clink-debits.md
@@ -16,7 +16,7 @@ The ideal flow is simple: A user shares their static debit pointer (e.g., via th
 
 A debit request pointer is a bech32 encoded string (per [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)) prefixed with `ndebit`. The encoded string includes the following TLV (Type-Length-Value) items:
 
-- `0`: The 32-byte public key of the **node service** (hex encoded) — the service that receives kind `21002` events and processes debits.
+- `0`: The 32 raw bytes of the **node service** public key (represented as hexadecimal outside the encoded pointer) — the service that receives kind `21002` events and processes debits.
 - `1`: Relay URL where the node service listens for requests.
 - `2`: (Optional) An opaque pointer identifier string, used by the node service to route or identify the request target (e.g., a specific budget, account, or application).
 - `3`: (Optional) A session identifier (`k1`). Exactly 32 bytes of opaque binary data, used to correlate a single debit attempt (e.g., an ATM withdrawal session). MUST be generated with a cryptographically secure random number generator when present.
@@ -71,7 +71,7 @@ The debit pointer is the complete bech32 string: `ndebit1<data>`. There is no se
 
 ### NIP-01 User Metadata
 
-Users can advertise their primary debit pointer in their kind `0` metadata event using a `clink_debit` field (or similar agreed-upon field name) to allow applications default awareness of their payment source.
+Users can advertise their primary debit pointer in their kind `0` metadata event using the `clink_debit` field to allow applications default awareness of their payment source.
 
 **Example:**
 ```json
@@ -82,8 +82,6 @@ Users can advertise their primary debit pointer in their kind `0` metadata event
   // ...
 }
 ```
-*(Note: The exact field name, like `clink_debit` or `nip68` if backward compatibility is desired, should be finalized)*
-
 ### NIP-05 Lookup
 
 To simplify connecting apps to wallets via NIP-05 identifiers (like Lightning Addresses), NIP-05 servers can include a mapping for debit pointers using the `clink_debit` field.

--- a/specs/clink-enroll.md
+++ b/specs/clink-enroll.md
@@ -52,6 +52,14 @@ There is no separate account pointer in an Enroll request: the service pubkey is
   - `["clink_version", "1"]`
 - **Content:** NIP-44 encrypted JSON (same pattern as Offers / Debits / Manage)
 
+### Protocol Versioning
+
+CLINK events utilize a mandatory `["clink_version", "1"]` tag. This ensures:
+1. **Disambiguation:** Explicitly identifies events belonging to the CLINK protocol, preventing conflicts if other NIPs use the same event kind (`21004`).
+2. **Version Compatibility:** Allows clients and services to verify they are using compatible versions of the CLINK protocol specification. Future versions may increment the version number (e.g., `"2"`).
+
+Implementations MUST include this tag in both request and response events and SHOULD reject events lacking this tag or having an unsupported version number.
+
 ## Proof of work
 
 Enroll creates an account for a new key, or returns the existing account if that key is already enrolled. Unbounded free enroll can be abused. Services **MAY** require [NIP-13](https://github.com/nostr-protocol/nips/blob/master/13.md) proof of work on the kind `21004` request to make mass scripted enrollment expensive, while a single enroll on a phone, browser tab, or low-resource agent stays interactive.
@@ -81,7 +89,7 @@ Blindly hashing at 18 and then discovering the service wants 20 wastes a full mi
 
 **Beacon fast-path (optional):** see [CLINK Beacon](clink-beacon.md). A fresh kind `30078` beacon with `enroll_difficulty` lets clients skip the probe before mining.
 
-**Portable discovery (normative):** clients learn difficulty by **probing** — send Enroll with no PoW (or difficulty `0`). If the service requires PoW, it responds with code `5` and `required_difficulty`; the client mines once at that value and retries. Every CLINK Enroll implementation MUST support this path. Portable clients MUST still probe when beacon is missing, stale, or not implemented.
+**Portable discovery (normative):** clients learn difficulty by **probing** — send an Enroll request with no `nonce` tag (or `target_difficulty` `0`). If the service requires PoW, it SHOULD respond with code `5` and `required_difficulty`; the client mines once at that value and retries. Every CLINK Enroll implementation MUST support this path. Portable clients MUST still probe when beacon is missing, stale, or not implemented.
 
 If the probe receives no response, the client MAY retry Enroll with the recommended **18** bits as a local default. If the service does not require PoW, the probe itself is the Enroll request and a successful response completes enrollment. On code `5`, mine at `required_difficulty` and retry **once**.
 
@@ -137,7 +145,7 @@ Error responses use the GFY envelope (`"res": "GFY"`), consistent with other CLI
 {
   "res": "GFY",
   "code": 5,
-  "error": "insufficient proof of work",
+  "error": "Insufficient proof of work",
   "required_difficulty": 18
 }
 ```
@@ -146,14 +154,14 @@ Error responses use the GFY envelope (`"res": "GFY"`), consistent with other CLI
 
 Error codes (aligned with other CLINK specs):
 
-| Code | Meaning |
-|------|---------|
-| 1 | Denied / not allowed |
-| 2 | Temporary Failure / Service unavailable |
-| 3 | Expired Request |
-| 4 | Rate limited |
-| 5 | Insufficient NIP-13 proof of work (see `required_difficulty`) |
-| 6 | Invalid Request |
+| Code | Meaning | Expected Extra Fields |
+|------|---------|-----------------------|
+| 1 | Denied / not allowed | |
+| 2 | Temporary Failure / Service unavailable | |
+| 3 | Expired Request | `delta`: `{"max_delta_ms": 30000, "actual_delta_ms": <calculated_delta>}` |
+| 4 | Rate limited | `retry_after`: `<unix_timestamp>` (optional) |
+| 5 | Insufficient NIP-13 proof of work | `required_difficulty`: `<integer>` |
+| 6 | Invalid Request | |
 
 ## Owner policy (normative for reference servers)
 
@@ -192,8 +200,8 @@ nprofile (service) + user key
 - Returned `ndebit` is powerful for the **owner key** under owner policy; clients MUST treat the secret key as a full account credential.
 - Do not overload Enroll with grant minting — that recreates ambient authority and breaks Manage’s delegation model.
 
-## Reference implementation
+## Reference Implementations
 
 - Spec repo: this document
-- Go CLI/SDK: [clink-go](https://github.com/shocknet/clink-go) (`clinkctl enroll`)
 - Reference server: [Lightning.Pub](https://github.com/shocknet/Lightning.Pub)
+- **SDK:** [CLINK SDK](https://github.com/shocknet/ClinkSDK) ([`@shocknet/clink-sdk`](https://www.npmjs.com/package/@shocknet/clink-sdk) on npm)

--- a/specs/clink-enroll.md
+++ b/specs/clink-enroll.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-**CLINK Enroll** binds a Nostr key to an account (pointer) on a node service and returns that account’s default static CLINK pointers (`noffer1…`, `ndebit1…`, `nmanage1…`).
+**CLINK Enroll** binds a Nostr key to an account on a node service and returns that account’s default static CLINK resource pointers (`noffer1…`, `ndebit1…`, `nmanage1…`).
 
 It is how headless clients, CLIs, and agents that act **as** the user (direct-use principal) send an **Enroll request** to provision an account on a node. It does **not** grant third parties spend or manage rights.
 
@@ -10,7 +10,7 @@ It is how headless clients, CLIs, and agents that act **as** the user (direct-us
 
 ## Motivation
 
-Offers, Debits, and Manage all require a service pubkey, relay, and account pointer. Without Enroll, clients must use proprietary wallet RPC (e.g. Lightning.Pub `GetUserInfo`) to create an account and learn those pointers.
+Offers, Debits, and Manage use a service pubkey, relay, and resource-specific identifiers. Without Enroll, clients must use proprietary wallet RPC (e.g. Lightning.Pub `GetUserInfo`) to create an account and learn the resulting resource pointers.
 
 Enroll makes account provisioning a portable CLINK protocol so a client can:
 
@@ -37,7 +37,7 @@ Input is the **node service** identity only:
 - Service pubkey (32-byte)
 - Relay URL(s) where the service listens
 
-There is no separate “app” pubkey in the pointer model. Account identity on the service is an opaque **pointer** (user id) chosen by the service.
+There is no separate account pointer in an Enroll request: the service pubkey is the request target. The useful resource-specific identifiers are returned inside the resulting `noffer`, `ndebit`, and `nmanage` strings.
 
 ## Nostr Events
 
@@ -83,7 +83,7 @@ Blindly hashing at 18 and then discovering the service wants 20 wastes a full mi
 
 **Portable discovery (normative):** clients learn difficulty by **probing** — send Enroll with no PoW (or difficulty `0`). If the service requires PoW, it responds with code `5` and `required_difficulty`; the client mines once at that value and retries. Every CLINK Enroll implementation MUST support this path. Portable clients MUST still probe when beacon is missing, stale, or not implemented.
 
-If the probe is ignored or the service does not require PoW, the client MAY enroll with no PoW or with the recommended **18** bits as a local default. On code `5`, mine at `required_difficulty` and retry **once**.
+If the probe receives no response, the client MAY retry Enroll with the recommended **18** bits as a local default. If the service does not require PoW, the probe itself is the Enroll request and a successful response completes enrollment. On code `5`, mine at `required_difficulty` and retry **once**.
 
 Services that require PoW SHOULD return code `5` + `required_difficulty` on insufficient work so the probe path works.
 
@@ -95,21 +95,13 @@ If the requestor pubkey already owns an account, a service that normally require
 
 ## Request
 
-Kind `21004` **Enroll request** event. Empty object or optional fields:
+Kind `21004` **Enroll request** event. Its payload is an empty object:
 
 ```json
 {}
 ```
 
-Optional:
-
-```json
-{
-  "preferred_pointer": "<hint>"
-}
-```
-
-Services MAY ignore `preferred_pointer`. Services MUST associate the resulting account with the **request event’s pubkey**.
+Services MUST associate the resulting account with the **request event’s pubkey**.
 
 ## Response (success)
 
@@ -129,11 +121,11 @@ Services MAY ignore `preferred_pointer`. Services MUST associate the resulting a
 | `ndebit` | Static debit pointer for this account |
 | `nmanage` | Manage pointer for this account |
 
-Returned bech32s MUST use:
+Each returned bech32 string MUST follow its respective Offers, Debits, or Manage specification. In particular, returned strings MUST use:
 
 - TLV `0` = **this service’s** pubkey
 - TLV `1` = a relay the service listens on (typically the relay used for the request)
-- TLV `2` = `pointer` (where the format includes a pointer)
+- TLV `2` = the resource-specific identifier defined by that format, where present
 
 Idempotency: repeating Enroll with the same key MUST return equivalent pointers (bech32 strings MAY differ only if relay preference changes).
 
@@ -165,7 +157,7 @@ Error codes (aligned with other CLINK specs):
 
 ## Owner policy (normative for reference servers)
 
-When the signer of a kind **21002** (Debit) or **21003** (Manage) request is the Nostr key that **owns** the account identified by the pointer (the same key that Enrolled):
+When the signer of a kind **21002** (Debit) or **21003** (Manage) request is the Nostr key that **owns** the account behind the resource pointer in that request (the same key that Enrolled):
 
 - The service MUST allow the operation without a prior third-party debit/manage authorization grant.
 - This does **not** authorize any other pubkey.

--- a/specs/clink-enroll.md
+++ b/specs/clink-enroll.md
@@ -73,7 +73,7 @@ This spec does **not** mandate that every deployment enforce PoW. Operators choo
 1. The request event MUST include a NIP-13 `nonce` tag: `["nonce", "<counter>", "<target_difficulty>"]`.
 2. The event id MUST have at least `target_difficulty` leading zero bits.
 3. `target_difficulty` in the tag MUST be ≥ the service’s required difficulty (committed target — reject “lucky” high-difficulty ids that commit to a lower target).
-4. Unless the request is rate-limited or the key is banned, the service MUST respond to insufficient PoW with error code `5` and `required_difficulty` so the client can remine once without guessing. Rate-limited requests or banned keys MAY receive code `4` or no response.
+4. The service MUST respond to insufficient PoW with error code `5` and `required_difficulty` so the client can remine once without guessing. Code `5` is that failure mode: the work is why enroll does not complete. A request already rejected as invalid, expired, or denied (codes `6`, `3`, `1`) does not require a PoW response. Rate-limited requests or banned keys MAY receive code `4` or no response instead of `5`.
 
 ### Recommended difficulty
 
@@ -91,7 +91,7 @@ Blindly hashing at 18 and then discovering the service wants 20 wastes a full mi
 
 **Beacon fast-path (recommended):** see [CLINK Beacon](clink-beacon.md). A fresh kind `30078` beacon with `enroll_difficulty` lets clients skip the probe before mining.
 
-**Portable discovery (normative):** In the absence of a beacon, clients learn difficulty by **probing** — send an Enroll request with no `nonce` tag (or `target_difficulty` `0`). If the service requires PoW and the request is neither rate-limited nor from a banned key, it MUST return code `5` and `required_difficulty`; the client mines once at that value and retries. Portable clients MUST support this probe and MUST use it when the beacon is missing, stale, or not implemented.
+**Portable discovery (normative):** In the absence of a beacon, clients learn difficulty by **probing** — send an Enroll request with no `nonce` tag (or `target_difficulty` `0`). If insufficient PoW is why the enroll does not complete, the service MUST return code `5` and `required_difficulty`; the client mines once at that value and retries. Portable clients MUST support this probe and MUST use it when the beacon is missing, stale, or not implemented.
 
 If the probe receives no response, the client MAY retry Enroll with the recommended **18** bits as a local default. If the service does not require PoW, the probe itself is the Enroll request and a successful response completes enrollment. On code `5`, mine at `required_difficulty` and retry **once**.
 

--- a/specs/clink-enroll.md
+++ b/specs/clink-enroll.md
@@ -87,11 +87,13 @@ Expected work scales as `2^bits` SHA-256 event-id trials. One extra bit ≈ 2× 
 
 Blindly hashing at 18 and then discovering the service wants 20 wastes a full mine on weak devices.
 
-**Beacon fast-path (optional):** see [CLINK Beacon](clink-beacon.md). A fresh kind `30078` beacon with `enroll_difficulty` lets clients skip the probe before mining.
+**Beacon fast-path (recommended):** see [CLINK Beacon](clink-beacon.md). A fresh kind `30078` beacon with `enroll_difficulty` lets clients skip the probe before mining.
 
-**Portable discovery (normative):** clients learn difficulty by **probing** — send an Enroll request with no `nonce` tag (or `target_difficulty` `0`). If the service requires PoW, it SHOULD respond with code `5` and `required_difficulty`; the client mines once at that value and retries. Every CLINK Enroll implementation MUST support this path. Portable clients MUST still probe when beacon is missing, stale, or not implemented.
+**Portable discovery (normative):** In the absence of a beacon, clients learn difficulty by **probing** — send an Enroll request with no `nonce` tag (or `target_difficulty` `0`). If the service requires PoW, it SHOULD respond with code `5` and `required_difficulty`; the client mines once at that value and retries. Every CLINK Enroll implementation MUST support this path. Portable clients MUST still probe when beacon is missing, stale, or not implemented.
 
 If the probe receives no response, the client MAY retry Enroll with the recommended **18** bits as a local default. If the service does not require PoW, the probe itself is the Enroll request and a successful response completes enrollment. On code `5`, mine at `required_difficulty` and retry **once**.
+
+**Note:** A huge difficulty from a beacon `enroll_difficulty` or a code `5` `required_difficulty` is a hang vector. Clients SHOULD NOT mine values well beyond the range above (>24): skip the beacon fast-path (probe), or return the GFY instead of remine.
 
 Services that require PoW SHOULD return code `5` + `required_difficulty` on insufficient work so the probe path works.
 
@@ -179,7 +181,7 @@ nprofile (service) + user key
         │
         ▼
   learn difficulty:
-   optional: kind 30078 beacon → enroll_difficulty (see CLINK Beacon)
+   recommended: kind 30078 beacon → enroll_difficulty (see CLINK Beacon)
    portable: Enroll with 0 PoW → code 5 + required_difficulty
         │
         ▼

--- a/specs/clink-enroll.md
+++ b/specs/clink-enroll.md
@@ -43,11 +43,54 @@ There is no separate “app” pubkey in the pointer model. Account identity on 
 - **Tags (request):**
   - `["p", "<service_pubkey>"]`
   - `["clink_version", "1"]`
+  - `["nonce", "<counter>", "<target_difficulty>"]` — [NIP-13](https://github.com/nostr-protocol/nips/blob/master/13.md) proof of work (see **Proof of work**)
 - **Tags (response):**
   - `["p", "<requestor_pubkey>"]`
   - `["e", "<request_event_id>"]`
   - `["clink_version", "1"]`
 - **Content:** NIP-44 encrypted JSON (same pattern as Offers / Debits / Manage)
+
+## Proof of work
+
+Enroll creates (or resumes) an account. Unbounded free enroll is a DoS / spam vector. Request events MUST carry [NIP-13](https://github.com/nostr-protocol/nips/blob/master/13.md) proof of work so mass scripted enrollment is expensive, while a single enroll on a phone, browser tab, or low-resource agent stays interactive.
+
+### Rules
+
+1. The kind `21004` **request** event MUST include a NIP-13 `nonce` tag: `["nonce", "<counter>", "<target_difficulty>"]`.
+2. The event id MUST have at least `target_difficulty` leading zero bits.
+3. `target_difficulty` in the tag MUST be ≥ the service’s required difficulty (committed target — services MUST reject “lucky” high-difficulty ids that commit to a lower target).
+4. Services MUST reject requests that fail (1)–(3), preferably with error code `4` and `required_difficulty` so clients can remine once.
+
+### Recommended difficulty
+
+| Setting | Bits | Intent |
+|---------|------|--------|
+| **Minimum allowed** | 16 | Floor for public enroll (~65k hashes expected) |
+| **Recommended default** | **18** | Deterrent for naive scripts; typically well under ~1s on a mid-range phone / browser WASM / small VPS agent |
+| **Stronger public** | 20 | ~1M hashes expected; still usually a few seconds on a phone, not “forever” |
+| **Avoid by default** | ≥ 22 | Fine for invite-gated or desktop-only services; too slow for shitty phones / casual web tabs |
+
+Expected work scales as `2^bits` SHA-256 event-id trials. One extra bit ≈ 2× wall time.
+
+Reference servers SHOULD default to **18** and MAY raise toward **20** under load. They MUST NOT require ≥ 22 for open public enroll unless they document that low-power clients are unsupported or offer an invite / lower-difficulty path.
+
+### Existing accounts
+
+If the requestor pubkey already owns an account on the service, the service MAY:
+
+- accept the same PoW requirement, or
+- accept a lower difficulty (including `0`) for idempotent “return my pointers” re-enroll
+
+New account creation MUST still meet the full required difficulty.
+
+### Advertising difficulty
+
+Services SHOULD advertise `required_difficulty` so clients mine once:
+
+- in error responses when PoW is insufficient (see below), and/or
+- out of band (e.g. service kind `0` / documentation)
+
+Clients SHOULD mine at the advertised value (or the recommended default **18** if unknown), and on code `4` remine at `required_difficulty`.
 
 ## Request
 
@@ -97,10 +140,13 @@ Idempotency: repeating Enroll with the same key MUST return the same `pointer` a
 
 ```json
 {
-  "code": 1,
-  "error": "human readable reason"
+  "code": 4,
+  "error": "insufficient proof of work",
+  "required_difficulty": 18
 }
 ```
+
+`required_difficulty` MUST be present when `code` is `4`.
 
 Suggested codes (align with other CLINK specs where practical):
 
@@ -109,6 +155,7 @@ Suggested codes (align with other CLINK specs where practical):
 | 1 | Denied / not allowed |
 | 2 | Rate limited |
 | 3 | Service unavailable |
+| 4 | Insufficient NIP-13 proof of work (see `required_difficulty`) |
 
 ## Owner policy (normative for reference servers)
 
@@ -125,8 +172,12 @@ Marketplace / agent keys that are **not** the account owner still require normal
 nprofile (service) + user key
         │
         ▼
+ mine NIP-13 PoW (default 18 bits) on kind 21004
+        │
+        ▼
    kind 21004 Enroll
         │
+        ├─ code 4 → remine at required_difficulty → retry
         ▼
  noffer / ndebit / nmanage
         │
@@ -137,7 +188,8 @@ nprofile (service) + user key
 
 ## Security considerations
 
-- Enroll proves control of a key and creates (or resumes) a custodial-or-self-hosted account on the service; services SHOULD rate-limit and MAY require invites.
+- Enroll proves control of a key and creates (or resumes) a custodial-or-self-hosted account on the service; services SHOULD rate-limit **and** require NIP-13 PoW for new accounts. PoW alone is not enough under a well-funded attacker — combine with rate limits / invites.
+- Recommended **18-bit** PoW aims for “annoying to spray thousands of accounts, fine for one human or agent on a phone.” Do not push public defaults into “wait forever on a weak device” territory (≥ 22).
 - Returned `ndebit` is powerful for the **owner key** under owner policy; clients MUST treat the secret key as a full account credential.
 - Do not overload Enroll with grant minting — that recreates ambient authority and breaks Manage’s delegation model.
 

--- a/specs/clink-enroll.md
+++ b/specs/clink-enroll.md
@@ -4,7 +4,9 @@
 
 **CLINK Enroll** binds a Nostr key to an account (pointer) on a node service and returns that account’s default static CLINK pointers (`noffer1…`, `ndebit1…`, `nmanage1…`).
 
-It is the bootstrap step for headless clients, CLIs, and agents that act **as** the user (direct-use principal). It does **not** grant third parties spend or manage rights.
+It is how headless clients, CLIs, and agents that act **as** the user (direct-use principal) send an **Enroll request** to provision an account on a node. It does **not** grant third parties spend or manage rights.
+
+**Terminology:** An **Enroll request** is a kind `21004` event (same request/response pattern as Offers and Debits). Successful enrollment **provisions** an account for the requestor’s signing key. This is not wallet “bootstrap node”, Pub bootstrap liquidity, or application first-run initialization.
 
 ## Motivation
 
@@ -43,7 +45,7 @@ There is no separate “app” pubkey in the pointer model. Account identity on 
 - **Tags (request):**
   - `["p", "<service_pubkey>"]`
   - `["clink_version", "1"]`
-  - `["nonce", "<counter>", "<target_difficulty>"]` — [NIP-13](https://github.com/nostr-protocol/nips/blob/master/13.md) proof of work (see **Proof of work**)
+  - `["nonce", "<counter>", "<target_difficulty>"]` — [NIP-13](https://github.com/nostr-protocol/nips/blob/master/13.md) proof of work when the service requires it (see **Proof of work**)
 - **Tags (response):**
   - `["p", "<requestor_pubkey>"]`
   - `["e", "<request_event_id>"]`
@@ -52,49 +54,48 @@ There is no separate “app” pubkey in the pointer model. Account identity on 
 
 ## Proof of work
 
-Enroll creates (or resumes) an account. Unbounded free enroll is a DoS / spam vector. Request events MUST carry [NIP-13](https://github.com/nostr-protocol/nips/blob/master/13.md) proof of work so mass scripted enrollment is expensive, while a single enroll on a phone, browser tab, or low-resource agent stays interactive.
+Enroll creates an account for a new key, or returns the existing account if that key is already enrolled. Unbounded free enroll can be abused. Services **MAY** require [NIP-13](https://github.com/nostr-protocol/nips/blob/master/13.md) proof of work on the kind `21004` request to make mass scripted enrollment expensive, while a single enroll on a phone, browser tab, or low-resource agent stays interactive.
 
-### Rules
+This spec does **not** mandate that every deployment enforce PoW. Operators choose based on their threat model (open public node vs invite-only vs already rate-limited). When a service *does* require PoW, the rules below apply.
 
-1. The kind `21004` **request** event MUST include a NIP-13 `nonce` tag: `["nonce", "<counter>", "<target_difficulty>"]`.
+### When PoW is required
+
+1. The request event MUST include a NIP-13 `nonce` tag: `["nonce", "<counter>", "<target_difficulty>"]`.
 2. The event id MUST have at least `target_difficulty` leading zero bits.
-3. `target_difficulty` in the tag MUST be ≥ the service’s required difficulty (committed target — services MUST reject “lucky” high-difficulty ids that commit to a lower target).
-4. Services MUST reject requests that fail (1)–(3), preferably with error code `4` and `required_difficulty` so clients can remine once.
+3. `target_difficulty` in the tag MUST be ≥ the service’s required difficulty (committed target — reject “lucky” high-difficulty ids that commit to a lower target).
+4. If PoW is insufficient, the service SHOULD respond with error code `4` and `required_difficulty` so the client can remine once without guessing.
 
 ### Recommended difficulty
 
 | Setting | Bits | Intent |
 |---------|------|--------|
-| **Minimum allowed** | 16 | Floor for public enroll (~65k hashes expected) |
-| **Recommended default** | **18** | Deterrent for naive scripts; typically well under ~1s on a mid-range phone / browser WASM / small VPS agent |
-| **Stronger public** | 20 | ~1M hashes expected; still usually a few seconds on a phone, not “forever” |
-| **Avoid by default** | ≥ 22 | Fine for invite-gated or desktop-only services; too slow for shitty phones / casual web tabs |
+| **Recommended** | **18** | Deters scripts; typically well under ~1s on a mid-range phone / browser tab / small agent harness |
+| **Stronger** | 20 | ~1M hashes; usually a few seconds on a phone |
+| **Heavy** | ≥ 22 | Avoid for open public enroll aimed at low-power clients |
 
 Expected work scales as `2^bits` SHA-256 event-id trials. One extra bit ≈ 2× wall time.
 
-Reference servers SHOULD default to **18** and MAY raise toward **20** under load. They MUST NOT require ≥ 22 for open public enroll unless they document that low-power clients are unsupported or offer an invite / lower-difficulty path.
+### Discover difficulty before mining
+
+Blindly hashing at 18 and then discovering the service wants 20 wastes a full mine on weak devices.
+
+**Beacon fast-path (optional):** see [CLINK Beacon](clink-beacon.md). A fresh kind `30078` beacon with `enroll_difficulty` lets clients skip the probe before mining.
+
+**Portable discovery (normative):** clients learn difficulty by **probing** — send Enroll with no PoW (or difficulty `0`). If the service requires PoW, it responds with code `4` and `required_difficulty`; the client mines once at that value and retries. Every CLINK Enroll implementation MUST support this path. Portable clients MUST still probe when beacon is missing, stale, or not implemented.
+
+If the probe is ignored or the service does not require PoW, the client MAY enroll with no PoW or with the recommended **18** bits as a local default. On code `4`, mine at `required_difficulty` and retry **once**.
+
+Services that require PoW SHOULD return code `4` + `required_difficulty` on insufficient work so the probe path works.
+
+Services that publish a CLINK beacon with `enroll_difficulty` MUST keep it in sync with what they enforce on kind `21004` (see [CLINK Beacon](clink-beacon.md)).
 
 ### Existing accounts
 
-If the requestor pubkey already owns an account on the service, the service MAY:
-
-- accept the same PoW requirement, or
-- accept a lower difficulty (including `0`) for idempotent “return my pointers” re-enroll
-
-New account creation MUST still meet the full required difficulty.
-
-### Advertising difficulty
-
-Services SHOULD advertise `required_difficulty` so clients mine once:
-
-- in error responses when PoW is insufficient (see below), and/or
-- out of band (e.g. service kind `0` / documentation)
-
-Clients SHOULD mine at the advertised value (or the recommended default **18** if unknown), and on code `4` remine at `required_difficulty`.
+If the requestor pubkey already owns an account, a service that normally requires PoW MAY accept lower difficulty (including none) for an idempotent “return my pointers”. New account creation, when PoW is enabled, SHOULD still meet the full requirement.
 
 ## Request
 
-Empty object or optional fields:
+Kind `21004` **Enroll request** event. Empty object or optional fields:
 
 ```json
 {}
@@ -172,12 +173,13 @@ Marketplace / agent keys that are **not** the account owner still require normal
 nprofile (service) + user key
         │
         ▼
- mine NIP-13 PoW (default 18 bits) on kind 21004
+ learn difficulty:
+   optional: kind 30078 beacon → enroll_difficulty (see CLINK Beacon)
+   portable: Enroll with 0 PoW → code 4 + required_difficulty
         │
         ▼
-   kind 21004 Enroll
+ mine if required, then kind 21004 Enroll
         │
-        ├─ code 4 → remine at required_difficulty → retry
         ▼
  noffer / ndebit / nmanage
         │
@@ -188,8 +190,8 @@ nprofile (service) + user key
 
 ## Security considerations
 
-- Enroll proves control of a key and creates (or resumes) a custodial-or-self-hosted account on the service; services SHOULD rate-limit **and** require NIP-13 PoW for new accounts. PoW alone is not enough under a well-funded attacker — combine with rate limits / invites.
-- Recommended **18-bit** PoW aims for “annoying to spray thousands of accounts, fine for one human or agent on a phone.” Do not push public defaults into “wait forever on a weak device” territory (≥ 22).
+- Enroll proves control of a key and creates an account on the service (or returns pointers for an account that key already has). Services SHOULD rate-limit new enrolls and MAY require PoW and/or invites.
+- When PoW is used, ~**18 bits** is a sensible default tradeoff. Clients SHOULD probe (code `4`) before mining so they do not double-hash on a phone.
 - Returned `ndebit` is powerful for the **owner key** under owner policy; clients MUST treat the secret key as a full account credential.
 - Do not overload Enroll with grant minting — that recreates ambient authority and breaks Manage’s delegation model.
 

--- a/specs/clink-enroll.md
+++ b/specs/clink-enroll.md
@@ -63,7 +63,7 @@ This spec does **not** mandate that every deployment enforce PoW. Operators choo
 1. The request event MUST include a NIP-13 `nonce` tag: `["nonce", "<counter>", "<target_difficulty>"]`.
 2. The event id MUST have at least `target_difficulty` leading zero bits.
 3. `target_difficulty` in the tag MUST be ≥ the service’s required difficulty (committed target — reject “lucky” high-difficulty ids that commit to a lower target).
-4. If PoW is insufficient, the service SHOULD respond with error code `4` and `required_difficulty` so the client can remine once without guessing.
+4. If PoW is insufficient, the service SHOULD respond with error code `5` and `required_difficulty` so the client can remine once without guessing.
 
 ### Recommended difficulty
 
@@ -81,11 +81,11 @@ Blindly hashing at 18 and then discovering the service wants 20 wastes a full mi
 
 **Beacon fast-path (optional):** see [CLINK Beacon](clink-beacon.md). A fresh kind `30078` beacon with `enroll_difficulty` lets clients skip the probe before mining.
 
-**Portable discovery (normative):** clients learn difficulty by **probing** — send Enroll with no PoW (or difficulty `0`). If the service requires PoW, it responds with code `4` and `required_difficulty`; the client mines once at that value and retries. Every CLINK Enroll implementation MUST support this path. Portable clients MUST still probe when beacon is missing, stale, or not implemented.
+**Portable discovery (normative):** clients learn difficulty by **probing** — send Enroll with no PoW (or difficulty `0`). If the service requires PoW, it responds with code `5` and `required_difficulty`; the client mines once at that value and retries. Every CLINK Enroll implementation MUST support this path. Portable clients MUST still probe when beacon is missing, stale, or not implemented.
 
-If the probe is ignored or the service does not require PoW, the client MAY enroll with no PoW or with the recommended **18** bits as a local default. On code `4`, mine at `required_difficulty` and retry **once**.
+If the probe is ignored or the service does not require PoW, the client MAY enroll with no PoW or with the recommended **18** bits as a local default. On code `5`, mine at `required_difficulty` and retry **once**.
 
-Services that require PoW SHOULD return code `4` + `required_difficulty` on insufficient work so the probe path works.
+Services that require PoW SHOULD return code `5` + `required_difficulty` on insufficient work so the probe path works.
 
 Services that publish a CLINK beacon with `enroll_difficulty` MUST keep it in sync with what they enforce on kind `21004` (see [CLINK Beacon](clink-beacon.md)).
 
@@ -115,7 +115,7 @@ Services MAY ignore `preferred_pointer`. Services MUST associate the resulting a
 
 ```json
 {
-  "pointer": "<account_pointer>",
+  "res": "ok",
   "noffer": "noffer1...",
   "ndebit": "ndebit1...",
   "nmanage": "nmanage1..."
@@ -124,7 +124,7 @@ Services MAY ignore `preferred_pointer`. Services MUST associate the resulting a
 
 | Field | Requirement |
 |-------|-------------|
-| `pointer` | Opaque account id used as TLV `2` in the returned bech32s |
+| `res` | `"ok"` on success |
 | `noffer` | Default spontaneous (or service-default) offer for this account |
 | `ndebit` | Static debit pointer for this account |
 | `nmanage` | Manage pointer for this account |
@@ -135,28 +135,33 @@ Returned bech32s MUST use:
 - TLV `1` = a relay the service listens on (typically the relay used for the request)
 - TLV `2` = `pointer` (where the format includes a pointer)
 
-Idempotency: repeating Enroll with the same key MUST return the same `pointer` and equivalent pointers (bech32 strings MAY differ only if relay preference changes).
+Idempotency: repeating Enroll with the same key MUST return equivalent pointers (bech32 strings MAY differ only if relay preference changes).
 
 ## Response (error)
 
+Error responses use the GFY envelope (`"res": "GFY"`), consistent with other CLINK interactive response protocols.
+
 ```json
 {
-  "code": 4,
+  "res": "GFY",
+  "code": 5,
   "error": "insufficient proof of work",
   "required_difficulty": 18
 }
 ```
 
-`required_difficulty` MUST be present when `code` is `4`.
+`required_difficulty` MUST be present when `code` is `5`.
 
-Suggested codes (align with other CLINK specs where practical):
+Error codes (aligned with other CLINK specs):
 
 | Code | Meaning |
 |------|---------|
 | 1 | Denied / not allowed |
-| 2 | Rate limited |
-| 3 | Service unavailable |
-| 4 | Insufficient NIP-13 proof of work (see `required_difficulty`) |
+| 2 | Temporary Failure / Service unavailable |
+| 3 | Expired Request |
+| 4 | Rate limited |
+| 5 | Insufficient NIP-13 proof of work (see `required_difficulty`) |
+| 6 | Invalid Request |
 
 ## Owner policy (normative for reference servers)
 
@@ -173,9 +178,9 @@ Marketplace / agent keys that are **not** the account owner still require normal
 nprofile (service) + user key
         │
         ▼
- learn difficulty:
+  learn difficulty:
    optional: kind 30078 beacon → enroll_difficulty (see CLINK Beacon)
-   portable: Enroll with 0 PoW → code 4 + required_difficulty
+   portable: Enroll with 0 PoW → code 5 + required_difficulty
         │
         ▼
  mine if required, then kind 21004 Enroll
@@ -191,7 +196,7 @@ nprofile (service) + user key
 ## Security considerations
 
 - Enroll proves control of a key and creates an account on the service (or returns pointers for an account that key already has). Services SHOULD rate-limit new enrolls and MAY require PoW and/or invites.
-- When PoW is used, ~**18 bits** is a sensible default tradeoff. Clients SHOULD probe (code `4`) before mining so they do not double-hash on a phone.
+- When PoW is used, ~**18 bits** is a sensible default tradeoff. Clients SHOULD probe (code `5`) before mining so they do not double-hash on a phone.
 - Returned `ndebit` is powerful for the **owner key** under owner policy; clients MUST treat the secret key as a full account credential.
 - Do not overload Enroll with grant minting — that recreates ambient authority and breaks Manage’s delegation model.
 

--- a/specs/clink-enroll.md
+++ b/specs/clink-enroll.md
@@ -1,0 +1,148 @@
+# CLINK Enroll Specification
+
+## Overview
+
+**CLINK Enroll** binds a Nostr key to an account (pointer) on a node service and returns that account’s default static CLINK pointers (`noffer1…`, `ndebit1…`, `nmanage1…`).
+
+It is the bootstrap step for headless clients, CLIs, and agents that act **as** the user (direct-use principal). It does **not** grant third parties spend or manage rights.
+
+## Motivation
+
+Offers, Debits, and Manage all require a service pubkey, relay, and account pointer. Without Enroll, clients must use proprietary wallet RPC (e.g. Lightning.Pub `GetUserInfo`) to create an account and learn those pointers.
+
+Enroll makes account provisioning a portable CLINK protocol so a client can:
+
+1. Talk to a service (`nprofile` / pubkey + relay)
+2. Ensure an account exists for its signing key
+3. Receive default `noffer` / `ndebit` / `nmanage` strings
+4. Proceed with kinds 21001–21003 only
+
+## Non-goals
+
+Enroll MUST NOT:
+
+- Create debit authorizations for other npubs
+- Create manage authorizations for other npubs
+- Expose balance, history, on-chain, or general wallet RPC
+- Replace [CLINK Debits](clink-debits.md) or [CLINK Manage](clink-manage.md)
+
+Third-party spend/manage remains Debits / Manage with explicit grants. Owner self-use is defined under **Owner policy** below (and MAY be implemented as server policy on 21002 / 21003 without a separate Enroll action).
+
+## Target
+
+Input is the **node service** identity only:
+
+- Service pubkey (32-byte)
+- Relay URL(s) where the service listens
+
+There is no separate “app” pubkey in the pointer model. Account identity on the service is an opaque **pointer** (user id) chosen by the service.
+
+## Nostr Events
+
+- **Kind:** `21004` (CLINK Enroll)
+- **Tags (request):**
+  - `["p", "<service_pubkey>"]`
+  - `["clink_version", "1"]`
+- **Tags (response):**
+  - `["p", "<requestor_pubkey>"]`
+  - `["e", "<request_event_id>"]`
+  - `["clink_version", "1"]`
+- **Content:** NIP-44 encrypted JSON (same pattern as Offers / Debits / Manage)
+
+## Request
+
+Empty object or optional fields:
+
+```json
+{}
+```
+
+Optional:
+
+```json
+{
+  "preferred_pointer": "<hint>"
+}
+```
+
+Services MAY ignore `preferred_pointer`. Services MUST associate the resulting account with the **request event’s pubkey**.
+
+## Response (success)
+
+```json
+{
+  "pointer": "<account_pointer>",
+  "noffer": "noffer1...",
+  "ndebit": "ndebit1...",
+  "nmanage": "nmanage1..."
+}
+```
+
+| Field | Requirement |
+|-------|-------------|
+| `pointer` | Opaque account id used as TLV `2` in the returned bech32s |
+| `noffer` | Default spontaneous (or service-default) offer for this account |
+| `ndebit` | Static debit pointer for this account |
+| `nmanage` | Manage pointer for this account |
+
+Returned bech32s MUST use:
+
+- TLV `0` = **this service’s** pubkey
+- TLV `1` = a relay the service listens on (typically the relay used for the request)
+- TLV `2` = `pointer` (where the format includes a pointer)
+
+Idempotency: repeating Enroll with the same key MUST return the same `pointer` and equivalent pointers (bech32 strings MAY differ only if relay preference changes).
+
+## Response (error)
+
+```json
+{
+  "code": 1,
+  "error": "human readable reason"
+}
+```
+
+Suggested codes (align with other CLINK specs where practical):
+
+| Code | Meaning |
+|------|---------|
+| 1 | Denied / not allowed |
+| 2 | Rate limited |
+| 3 | Service unavailable |
+
+## Owner policy (normative for reference servers)
+
+When the signer of a kind **21002** (Debit) or **21003** (Manage) request is the Nostr key that **owns** the account identified by the pointer (the same key that Enrolled):
+
+- The service MUST allow the operation without a prior third-party debit/manage authorization grant.
+- This does **not** authorize any other pubkey.
+
+Marketplace / agent keys that are **not** the account owner still require normal Debit / Manage authorization flows.
+
+## Client flow
+
+```
+nprofile (service) + user key
+        │
+        ▼
+   kind 21004 Enroll
+        │
+        ▼
+ noffer / ndebit / nmanage
+        │
+        ├── 21001 pay-into offer (others → you)
+        ├── 21002 pay-out via ndebit (you → invoice)   [owner auto-allow]
+        └── 21003 create offers via nmanage            [owner auto-allow]
+```
+
+## Security considerations
+
+- Enroll proves control of a key and creates (or resumes) a custodial-or-self-hosted account on the service; services SHOULD rate-limit and MAY require invites.
+- Returned `ndebit` is powerful for the **owner key** under owner policy; clients MUST treat the secret key as a full account credential.
+- Do not overload Enroll with grant minting — that recreates ambient authority and breaks Manage’s delegation model.
+
+## Reference implementation
+
+- Spec repo: this document
+- Go CLI/SDK: [clink-go](https://github.com/shocknet/clink-go) (`clinkctl enroll`)
+- Reference server: [Lightning.Pub](https://github.com/shocknet/Lightning.Pub)

--- a/specs/clink-enroll.md
+++ b/specs/clink-enroll.md
@@ -73,7 +73,7 @@ This spec does **not** mandate that every deployment enforce PoW. Operators choo
 1. The request event MUST include a NIP-13 `nonce` tag: `["nonce", "<counter>", "<target_difficulty>"]`.
 2. The event id MUST have at least `target_difficulty` leading zero bits.
 3. `target_difficulty` in the tag MUST be ≥ the service’s required difficulty (committed target — reject “lucky” high-difficulty ids that commit to a lower target).
-4. If PoW is insufficient, the service SHOULD respond with error code `5` and `required_difficulty` so the client can remine once without guessing.
+4. Unless the request is rate-limited or the key is banned, the service MUST respond to insufficient PoW with error code `5` and `required_difficulty` so the client can remine once without guessing. Rate-limited requests or banned keys MAY receive code `4` or no response.
 
 ### Recommended difficulty
 
@@ -91,13 +91,11 @@ Blindly hashing at 18 and then discovering the service wants 20 wastes a full mi
 
 **Beacon fast-path (recommended):** see [CLINK Beacon](clink-beacon.md). A fresh kind `30078` beacon with `enroll_difficulty` lets clients skip the probe before mining.
 
-**Portable discovery (normative):** In the absence of a beacon, clients learn difficulty by **probing** — send an Enroll request with no `nonce` tag (or `target_difficulty` `0`). If the service requires PoW, it SHOULD respond with code `5` and `required_difficulty`; the client mines once at that value and retries. Every CLINK Enroll implementation MUST support this path. Portable clients MUST still probe when beacon is missing, stale, or not implemented.
+**Portable discovery (normative):** In the absence of a beacon, clients learn difficulty by **probing** — send an Enroll request with no `nonce` tag (or `target_difficulty` `0`). If the service requires PoW and the request is neither rate-limited nor from a banned key, it MUST return code `5` and `required_difficulty`; the client mines once at that value and retries. Portable clients MUST support this probe and MUST use it when the beacon is missing, stale, or not implemented.
 
 If the probe receives no response, the client MAY retry Enroll with the recommended **18** bits as a local default. If the service does not require PoW, the probe itself is the Enroll request and a successful response completes enrollment. On code `5`, mine at `required_difficulty` and retry **once**.
 
 **Note:** A huge difficulty from a beacon `enroll_difficulty` or a code `5` `required_difficulty` is a hang vector. Clients SHOULD NOT mine values well beyond the range above (>24): skip the beacon fast-path (probe), or return the GFY instead of remine.
-
-Services that require PoW SHOULD return code `5` + `required_difficulty` on insufficient work so the probe path works.
 
 Services that publish a CLINK beacon with `enroll_difficulty` MUST keep it in sync with what they enforce on kind `21004` (see [CLINK Beacon](clink-beacon.md)).
 

--- a/specs/clink-enroll.md
+++ b/specs/clink-enroll.md
@@ -52,6 +52,8 @@ There is no separate account pointer in an Enroll request: the service pubkey is
   - `["clink_version", "1"]`
 - **Content:** NIP-44 encrypted JSON (same pattern as Offers / Debits / Manage)
 
+Clients MUST accept an Enroll response only if its NIP-01 event ID and signature are valid, its author is the expected service pubkey, its kind and `clink_version` are supported, and its `p` and `e` tags match the requestor pubkey and request event ID.
+
 ### Protocol Versioning
 
 CLINK events utilize a mandatory `["clink_version", "1"]` tag. This ensures:

--- a/specs/clink-manage.md
+++ b/specs/clink-manage.md
@@ -196,6 +196,7 @@ When a request cannot be fulfilled, the wallet service MAY respond with a GFY er
 - App sends a Kind 21003 request to the wallet server.
 - Wallet server prompts user for approval (or applies rules).
 - On approval, the server creates/updates/deletes the offer and responds.
+- Self-use requests signed by the account owner key do not require a prior third-party delegation grant (see **Owner policy** in [CLINK Enroll](clink-enroll.md)).
 
 #### Security & Rules
 - All requests are signed and auditable.

--- a/specs/clink-manage.md
+++ b/specs/clink-manage.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-CLINK Manage defines a protocol for delegated management of wallet resources by external applications. Using a bech32-encoded pointer (`nmanage1...`), users can grant external applications specific, auditable rights to manage resources (such as offers) on their wallet server. The protocol is extensible: this document defines the general framework and the first managed resource (offers).
+CLINK Manage defines a protocol for external applications to request management operations on wallet resources. A bech32-encoded pointer (`nmanage1...`) identifies the wallet server and optional account context; the server authenticates the requesting app by its event pubkey and applies the user's delegation rules. The protocol is extensible: this document defines the general framework and the first managed resource (offers).
 
 ## Motivation
 
@@ -11,7 +11,7 @@ Many Lightning and Nostr use-cases require apps to manage resources on behalf of
 ## Pointer Format
 
 A CLINK Manage pointer is a bech32-encoded string (per [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)) prefixed with `nmanage1`. The encoded TLVs are:
-- `0`: 32-byte pubkey of the user's wallet server (hex encoded)
+- `0`: 32 raw bytes of the user's wallet server pubkey (represented as hexadecimal outside the encoded pointer)
 - `1`: recommended relay URL
 - `2`: (optional) pointer ID (for multi-account, etc.)
 
@@ -75,6 +75,7 @@ Allows an app to create, update, and delete offers on the user's wallet server.
   ```json
   {
     "resource": "offer",
+    "pointer": "<pointer_id>", // Optional
     "action": "list"
   }
   ```

--- a/specs/clink-offers.md
+++ b/specs/clink-offers.md
@@ -16,19 +16,19 @@ This approach enables truly spontaneous payments that work seamlessly across all
 
 The static payment code is a single bech32 encoded string (per [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)). Its human-readable prefix (HRP) is `noffer`. Per bech32, the encoded form is the HRP, a separator character `1`, then the data — so a valid offer string is literally `noffer1<data>` with no colon or other delimiter (e.g. `noffer1qvq...`, not `noffer:noffer1...`). The encoded data includes the following TLV (Type-Length-Value) items:
 
-- `0`: The 32-byte public key of the receiving service (hex encoded).
+- `0`: The 32 raw bytes of the receiving service's public key (represented as hexadecimal outside the encoded pointer).
 - `1`: A recommended relay URL where the receiving service listens for payment requests.
 - `2`: An opaque offer identifier string (defined by the receiving service).
-- `3`: (Optional) A flag indicating the pricing type:
+- `3`: (Optional) A one-byte flag indicating the pricing type:
   - `0`: Fixed price (Price stated in TLV `4`)
   - `1`: Variable price (Price determined by the service upon request, e.g., based on fiat conversion)
   - `2`: Spontaneous payment (Payer specifies the amount in the request)
-- `4`: (Optional) The price in satoshis (integer) primarily for display purposes or fixed price offers.
-- `5`: (Optional) Currency code (e.g., "USD", "EUR") if the price in TLV 4 represents a non-satoshi amount. If present, pricing type `1` (Variable) MUST be used.
+- `4`: (Optional) The price in satoshis (integer), primarily for display purposes or fixed price offers.
+- `5`: (Optional) A currency code (e.g., "USD", "EUR") identifying the reference currency a service uses to determine a variable price. If present, pricing type `1` (Variable) MUST be used and TLV `4` MUST be omitted.
 
 **Default Behavior:** If neither price (TLV `4`) nor pricing type (TLV `3`) is present, the offer SHOULD be treated as type `2` (Spontaneous payment).
 
-**Amount Unit:** Amounts in TLV `4` and request/response payloads are specified in **satoshis**.
+**Amount Unit:** Amounts in TLV `4` and request/response payloads are specified in **whole satoshis**.
 
 **Example Structure:**
 ```
@@ -38,7 +38,7 @@ noffer1...
   2: <offer_id_string>
   3: <pricing_type_flag> (0, 1, or 2, optional)
   4: <price_in_sats> (integer, optional)
-  5: <currency_code> (string, optional, requires type 1)
+  5: <currency_code> (string, optional, requires type 1 and excludes TLV 4)
 ```
 
 ### Display and QR Encoding
@@ -55,7 +55,7 @@ The static payment code is the complete bech32 string: `noffer1<data>`. There is
 
 ### NIP-01 User Metadata
 
-Users or services can advertise a default/primary offer (typically for spontaneous payments) in their kind `0` metadata event using a `clink_offer` field (or similar).
+Users or services can advertise a default/primary offer (typically for spontaneous payments) in their kind `0` metadata event using the `clink_offer` field.
 
 **Example:**
 ```json
@@ -275,7 +275,7 @@ Implementations MUST include this tag in both request and response events and SH
     *   Success: Encrypted payload contains `{"bolt11":"..."}`.
     *   Failure: Encrypted payload contains `{"error":"...","code":...,"range":{"min":...,"max":...}}`.
 6.  **Payment**: Payer's wallet receives the response, decrypts it.
-    *   If `ok`, presents the invoice to the user for payment (or pays automatically via NWC/CLINK Debits etc.).
+    *   If `bolt11` is present, presents the invoice to the user for payment (or pays automatically).
     *   If `error`, displays the reason to the user.
 7.  **Receipt (Optional)**: After successful payment, the receiving service MAY provide a receipt. If the original request was a NIP-57 zap, the service generates and publishes a `kind: 9735` zap receipt. For other interactions, it MAY send a direct `kind: 21001` Payment Receipt event (see below) to the payer.
 
@@ -347,4 +347,4 @@ This flow provides a closed loop for programmatic interactions, allowing the pay
 - **Wallet Node:** [Lightning.Pub](https://github.com/shocknet/Lightning.Pub)
 - **Wallet Client:** [ShockWallet](https://shockwallet.app)
 - **SDK:** [CLINK SDK](https://github.com/shocknet/ClinkSDK)
-- **Demo Client:** [clinkme.dev](https://clinkme.dev/) 
+- **Demo Client:** [clinkme.dev](https://clinkme.dev/)


### PR DESCRIPTION
## Summary

Adds two CLINK specs for headless / CLI account setup and node discovery:

- **[CLINK Enroll](specs/clink-enroll.md)** (kind `21004`) — Enroll request/response to provision a Nostr key on a node service and receive default `noffer` / `ndebit` / `nmanage` pointers without proprietary wallet RPC.
- **[CLINK Beacon](specs/clink-beacon.md)** (kind `30078`) — Optional replaceable heartbeat for node liveness, persona, fee disclosure, Enroll PoW hints, and operator-linked discovery.

README updated with spec links and event-kind rows.

### Enroll highlights

- Direct-use only: does not mint third-party debit/manage grants.
- **Owner policy**: enrolled key MAY self-debit / self-manage without separate grants.
- Optional **NIP-13 PoW** on enroll (recommended ~18 bits); portable **probe** path (code `4` + `required_difficulty`) is normative.

### Beacon highlights

- **`d=clink-node`** — service heartbeat (persona, `fees`, `enroll_difficulty`, `supported_kinds`, optional `operator_npub`).
- **`d=clink-node-operator`** / **`clink-node-operator-revoke`** — bidirectional operator linkage with affinity-scam defense.
- Revocation via replaceable state
- Operator-first discovery: fetch operator attestation, then confirm `operator_npub` on each service beacon (not `#operator` scan alone).
- Beacon is optional optimization; Enroll probe remains the portable fallback.