### PR TITLE
Ecosystem: add LNbits-CLINK

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Where NWC is deferential to LNURL and scoped for a specific task, **CLINK is fun
 | [Vendure-CLINK](https://github.com/WoompaLoompa/vendure-clink) | E-commerce Plugin | Offers | Bitcoin Lightning payment plugin for Vendure via CLINK. |
 | [Medusa-CLINK](https://github.com/WoompaLoompa/medusa-clink) | E-commerce Plugin | Offers, Debits | Bitcoin Lightning payments and subscriptions for Medusa.js via CLINK. |
 | [Electrum CLINK](https://github.com/BareBits/electrum_clink) | Wallet Plugin | Offers | Electrum plugin for receiving Lightning payments via CLINK noffers. |
+| [LNbits-CLINK](https://github.com/WoompaLoompa/lnbits-clink) | LNbits Extension | Offers, Debits | Nostr-native Lightning for LNbits: offers, pay offers, subscriptions auto-renew and funding source via CLINK. |
 
 | *Your project here* | - | - | PR welcome! |
 


### PR DESCRIPTION
Adds [LNbits-CLINK](https://github.com/WoompaLoompa/lnbits-clink) to the ecosystem table.

**lnbits-clink** brings Nostr-native Lightning to LNbits: publish `noffer1...` offers and receive payments, pay remote CLINK offers, run subscriptions with auto-renew over kind 21002 debits, and use CLINK (e.g. Lightning.Pub) as a funding source — no Lightning.Pub instance required to run a node service.

Implements CLINK Offers (kind 21001) and CLINK Debits (kind 21002), matching the existing entries (Woo-CLINK, BTCPay-CLINK, etc.) from the same author.